### PR TITLE
Change to unified project versioning

### DIFF
--- a/SharpLearning.sln
+++ b/SharpLearning.sln
@@ -53,6 +53,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpLearning.Neural.Test",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpLearning.InputOutput", "src\SharpLearning.InputOutput\SharpLearning.InputOutput.csproj", "{D283D41E-AA14-44C5-AFB0-EBE6B34F3B7D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{55C8F585-6918-4373-A349-EDF167D77FBB}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+	  <Version>0.26.2.0</Version>
+    <AssemblyVersion>0.26.2.0</AssemblyVersion>
+    <FileVersion>0.26.2.0</FileVersion>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Authors>Mads Dabros</Authors>
+    <Copyright>Copyright © Mads Dabros 2014</Copyright>
+    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
+  </PropertyGroup>
+</Project>

--- a/src/SharpLearning.AdaBoost/SharpLearning.AdaBoost.csproj
+++ b/src/SharpLearning.AdaBoost/SharpLearning.AdaBoost.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.AdaBoost</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides learning algorithms and models for AdaBoost regression and classification.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>adaboost machinelearning classification regression machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.Common.Interfaces/SharpLearning.Common.Interfaces.csproj
+++ b/src/SharpLearning.Common.Interfaces/SharpLearning.Common.Interfaces.csproj
@@ -7,18 +7,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.Common.Interfaces</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides common interfaces for SharpLearning.</Description>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/SharpLearning.CrossValidation/SharpLearning.CrossValidation.csproj
+++ b/src/SharpLearning.CrossValidation/SharpLearning.CrossValidation.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.CrossValidation</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides cross-validation, training/test set samplers and learning curves for SharpLearning.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>crossvalidation cross validation sampling learningcurves machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.DecisionTrees/SharpLearning.DecisionTrees.csproj
+++ b/src/SharpLearning.DecisionTrees/SharpLearning.DecisionTrees.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.DecisionTrees</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides learning algorithms and models for DecisionTree regression and classification.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>decisiontrees machinelearning classification regression machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.Ensemble/SharpLearning.Ensemble.csproj
+++ b/src/SharpLearning.Ensemble/SharpLearning.Ensemble.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.Ensemble</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides ensemble learning for regression and classification.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>ensemblelearning machinelearning classification regression machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.FeatureTransformations/SharpLearning.FeatureTransformations.csproj
+++ b/src/SharpLearning.FeatureTransformations/SharpLearning.FeatureTransformations.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.FeatureTransformations</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides matrix and CsvRow transforms.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>normalization minmax onehot missingvalues</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.GradientBoost/SharpLearning.GradientBoost.csproj
+++ b/src/SharpLearning.GradientBoost/SharpLearning.GradientBoost.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.GradientBoost</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides learning algorithms and models for GradientBoost regression and classification.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>gradientboost machinelearning classification regression machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.InputOutput/SharpLearning.InputOutput.csproj
+++ b/src/SharpLearning.InputOutput/SharpLearning.InputOutput.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.InputOutput</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides CsvParser and serialization for SharpLearning.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>serialization csv parsing</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.Metrics/SharpLearning.Metrics.csproj
+++ b/src/SharpLearning.Metrics/SharpLearning.Metrics.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.Metrics</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides classification, regression, impurity and ranking metrics.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>metrics machinelearning classification regression machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.Neural/SharpLearning.Neural.csproj
+++ b/src/SharpLearning.Neural/SharpLearning.Neural.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.Neural</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides learning algorithms and models for neural net regression and classification.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>neural network convolutional deep learning machinelearning classification regression machine</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.Optimization/SharpLearning.Optimization.csproj
+++ b/src/SharpLearning.Optimization/SharpLearning.Optimization.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.Optimization</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides optimization algorithms.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>optimization machinelearning grid search random particle swarm neldermead nelder mead smo machine learning</PackageTags>
   </PropertyGroup>
 

--- a/src/SharpLearning.RandomForest/SharpLearning.RandomForest.csproj
+++ b/src/SharpLearning.RandomForest/SharpLearning.RandomForest.csproj
@@ -7,18 +7,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Authors>Mads Dabros</Authors>
     <PackageId>SharpLearning.RandomForest</PackageId>
-    <Version>0.26.2.0</Version>
-    <AssemblyVersion>0.26.2.0</AssemblyVersion>
-    <FileVersion>0.26.2.0</FileVersion>
-    <NeutralLanguage>en</NeutralLanguage>
     <Description>Provides learning algorithms and models for RandomForest and ExtraTrees regression and classification.</Description>
-    <Copyright>Copyright © Mads Dabros 2014</Copyright>
-    <PackageLicenseUrl>https://github.com/mdabros/SharpLearning/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/mdabros/SharpLearning</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mdabros/SharpLearning</RepositoryUrl>
     <PackageTags>randomforest extratrees machinelearning classification regression machine learning</PackageTags>
   </PropertyGroup>
 


### PR DESCRIPTION
After the migration from .net framework/desktop to .net core, I decided to switch to individual versioning for each project in SharpLearning. However, since vsts continuous integration/delivery currently does not support skipping already published nuget packages, I have decided to switch back to unified versioning across all projects. This is done differently with .net core projects compared to .net framework projects. I followed the advice from this answer on stackoverflow: [sharedassemblyinfo-equivalent-in-net-core-projects](https://stackoverflow.com/questions/42790536/sharedassemblyinfo-equivalent-in-net-core-projects). 

This solution also allows to have assembly attributes shared among the projects in one location.