### PR TITLE
Add contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,5 +31,5 @@ Pull requests are usually created against the master branch, unless the pull req
     3. When the pull request has been approved, and author will merge the changes to the master.
  
 ## Coding standard
-SharpLearning follows the [microsoft C# coding conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions)
+SharpLearning follows the microsoft C# [naming](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines) and [coding](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions) guidelines
 relatively closely. In general, try to write code in similar style to what is already present in the existing files/projects.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+
+# Contributing
+
+There are several ways to contribute to SharpLearning.
+
+ 1. Add new issues with bug descriptions or feature suggestions.
+ 2. Add more examples to [SharpLearning.Examples](https://github.com/mdabros/SharpLearning.Examples).
+ 3. Solve existing issues by forking SharpLearning and creating a pull request.
+
+The procedure when contributing should follow the steps below:
+
+ 1. Add an issue.
+    1. Start the contribution with adding an issue. 
+    2. Before writing the issue, make sure a duplicate does not already exist.    
+    3. The issue should contain a description of the bug or feature suggestion.
+This provides documentation and makes it possible to discuss the issue before time is spent on creating a pull request.
+
+When an issue has been approved by an author, it is time to fork SharpLearning and create a pull request.	
+
+ 2. Creating a pull request
+	1. [Fork the SharpLearning repository](https://help.github.com/articles/fork-a-repo/).
+    2. Code your contribution in the fork just created.
+    3. Create a pull request using the [github page](https://help.github.com/articles/creating-a-pull-request/). 
+Pull requests are usually created against the master branch, unless the pull request is part of a larger feature branch.
+    4. Please provide a description of your contribution in the pull request.
+    5. Link the pull request to the issue descripting the bug or feature.
+
+ 3. Review and feedback
+	1. When the pull request has been made, an author will review the changes, and provide feedback.
+    2. Discuss or implement the suggestions from the review.
+    3. When the pull request has been approved, and author will merge the changes to the master.
+ 
+## Coding standard
+SharpLearning follows the [microsoft C# coding conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions)
+relatively closely. In general, try to write code in similar style to what is already present in the existing files/projects.

--- a/README.md
+++ b/README.md
@@ -94,4 +94,12 @@ Container/IO packages:
 - **SharpLearning.InputOutput** - Provides csv parsing and serialization for SharpLearning.
 - **SharpLearning.FeatureTransformations** - Provides CsvRow transforms like missing value replacement and matrix transforms like MinMaxNormalization.
 
+Contributing
+------------
+Contributions are welcome in the following areas:
 
+ 1. Add new issues with bug descriptions or feature suggestions.
+ 2. Add more examples to [SharpLearning.Examples](https://github.com/mdabros/SharpLearning.Examples).
+ 3. Solve existing issues by forking SharpLearning and creating a pull request.
+
+When contributing, please follow the [contribution guide](https://github.com/mdabros/SharpLearning/blob/master/CONTRIBUTING.md).

--- a/SharpLearning.sln
+++ b/SharpLearning.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.26730.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpLearning.InputOutput.Test", "src\SharpLearning.InputOutput.Test\SharpLearning.InputOutput.Test.csproj", "{9B29211D-9211-4C36-872D-5747D6C51878}"
 EndProject
@@ -55,7 +55,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpLearning.InputOutput",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{55C8F585-6918-4373-A349-EDF167D77FBB}"
 	ProjectSection(SolutionItems) = preProject
+		CONTRIBUTING.md = CONTRIBUTING.md
 		src\Directory.Build.props = src\Directory.Build.props
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Adding a contribution guide to make it easier for other developers to contribute to SharpLearning. Some parts of the guide could use more details, but this should provide a start and make the contribution process more clear.