### PR TITLE
Fix for AccessViolationException in F64MatrixView and F64MatrixColumnView for large matrices

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.26.5.1</Version>
-    <AssemblyVersion>0.26.5.1</AssemblyVersion>
-    <FileVersion>0.26.5.1</FileVersion>
+	  <Version>0.26.6.1</Version>
+    <AssemblyVersion>0.26.6.1</AssemblyVersion>
+    <FileVersion>0.26.6.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Containers.Test/Views/F64MatrixViewTest.cs
+++ b/src/SharpLearning.Containers.Test/Views/F64MatrixViewTest.cs
@@ -45,6 +45,50 @@ namespace SharpLearning.Containers.Test.Views
             }
         }
 
+        [TestMethod]
+        public unsafe void F64MatrixView_LargePointerOffset()
+        {
+            const double testValue = 45;
+            var largeMatrix = LargeMatrix();
+
+            largeMatrix[largeMatrix.RowCount - 1, 0] = testValue;
+
+            using (var pinnedMatrix = largeMatrix.GetPinnedPointer())
+            {
+                var matrixView = pinnedMatrix.View();
+
+                var lastValue = *matrixView[largeMatrix.RowCount - 1];
+
+                Assert.AreEqual(lastValue, testValue);
+            }
+        }
+
+        /// <remarks>A matrix which needs a byte pointer offset larger than
+        /// int.MaxValue to access all records in the backing array</remarks>
+        private static F64Matrix LargeMatrix()
+        {
+            return new F64Matrix(int.MaxValue / sizeof(double) + 2, 1);
+        }
+
+        [TestMethod]
+        public void F64MatrixView_ColumnLargePointerOffset()
+        {
+            const double testValue = 45;
+            var largeMatrix = LargeMatrix();
+
+            largeMatrix[largeMatrix.RowCount - 1, 0] = testValue;
+
+            using (var pinnedMatrix = largeMatrix.GetPinnedPointer())
+            {
+                var columnView = pinnedMatrix.View().ColumnView(0);
+
+                var lastValue = columnView[largeMatrix.RowCount - 1];
+
+                Assert.AreEqual(lastValue, testValue);
+            }
+        }
+
+
         F64Matrix Matrix()
         {
             var features = new double[9] { 1, 2, 3,

--- a/src/SharpLearning.Containers.Test/Views/F64MatrixViewTest.cs
+++ b/src/SharpLearning.Containers.Test/Views/F64MatrixViewTest.cs
@@ -63,13 +63,6 @@ namespace SharpLearning.Containers.Test.Views
             }
         }
 
-        /// <remarks>A matrix which needs a byte pointer offset larger than
-        /// int.MaxValue to access all records in the backing array</remarks>
-        private static F64Matrix LargeMatrix()
-        {
-            return new F64Matrix(int.MaxValue / sizeof(double) + 2, 1);
-        }
-
         [TestMethod]
         public void F64MatrixView_ColumnLargePointerOffset()
         {
@@ -88,8 +81,14 @@ namespace SharpLearning.Containers.Test.Views
             }
         }
 
+        /// <remarks>A matrix which needs a byte pointer offset larger than
+        /// int.MaxValue to access all records in the backing array</remarks>
+        private F64Matrix LargeMatrix()
+        {
+            return new F64Matrix(int.MaxValue / sizeof(double) + 2, 1);
+        }
 
-        F64Matrix Matrix()
+        private F64Matrix Matrix()
         {
             var features = new double[9] { 1, 2, 3,
                                         10, 20, 30,
@@ -98,7 +97,7 @@ namespace SharpLearning.Containers.Test.Views
             return new F64Matrix(features, 3, 3);
         }
 
-        unsafe void AssertColumnView(double[] column, F64MatrixColumnView columnView)
+        private unsafe void AssertColumnView(double[] column, F64MatrixColumnView columnView)
         {
             for (int i = 0; i < column.Length; i++)
             {
@@ -107,7 +106,7 @@ namespace SharpLearning.Containers.Test.Views
         }
 
 
-        unsafe void AssertMatrixView(IMatrix<double> matrix, F64MatrixView view)
+        private unsafe void AssertMatrixView(IMatrix<double> matrix, F64MatrixView view)
         {
             for (int i = 0; i < matrix.RowCount; i++)
             {

--- a/src/SharpLearning.Containers/Views/F64MatrixColumnView.cs
+++ b/src/SharpLearning.Containers/Views/F64MatrixColumnView.cs
@@ -49,7 +49,7 @@ namespace SharpLearning.Containers.Views
 
         double* RowPtr(int row)
         {
-            return (double*)((byte*)m_dataPtr + row * m_strideInBytes);
+            return (double*)((byte*)m_dataPtr + (long)row * m_strideInBytes);
         }
     }
 }

--- a/src/SharpLearning.Containers/Views/F64MatrixView.cs
+++ b/src/SharpLearning.Containers/Views/F64MatrixView.cs
@@ -59,7 +59,7 @@ namespace SharpLearning.Containers.Views
         /// <returns></returns>
         public double* this[int row]
         {
-            get { return (double*)((byte*)m_dataPtr + row * m_strideInBytes); }
+            get { return (double*)((byte*)m_dataPtr + (long)row * m_strideInBytes); }
         }
 
         /// <summary>


### PR DESCRIPTION
#38 

Changed the pointer offsets applied in `F64MatrixColumnView.RowPtr(row)` and `F64MatrixView.this[row]` to use `long` instead of `int` - integer overflows were occurring when the length of the underlying `double[]` in `F64Matrix` passed `int.MaxValue / sizeof(double)`.