### PR TITLE
0.26.7.0: TimeSeriesCrossValidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently SharpLearning supports the following machine learning algorithms and m
 * Ensemble Learning
 
 All the machine learning algorithms have sensible default hyperparameters for easy usage. 
-However, several optimization methods are availible for hyperparameter tuning:
+However, several optimization methods are available for hyperparameter tuning:
 
 * GridSearch
 * RandomSearch
@@ -78,7 +78,7 @@ Learner and model packages:
 - **SharpLearning.AdaBoost** - Provides learning algorithms and models for AdaBoost regression and classification.
 - **SharpLearning.RandomForest** - Provides learning algorithms and models for RandomForest and ExtraTrees regression and classification.
 - **SharpLearning.GradientBoost** - Provides learning algorithms and models for GradientBoost regression and classification.
-- **SharpLearning.Neural** - Provides learning algorithms and models for neural net regression and classification. Layers availible for fully connected and covolutional nets.
+- **SharpLearning.Neural** - Provides learning algorithms and models for neural net regression and classification. Layers available for fully connected and covolutional nets.
 - **SharpLearning.Ensemble** - Provides ensemble learning for regression and classification. Makes it possible to combine the other learners/models from SharpLearning.
 - **SharpLearning.Common.Interfaces** - Provides common interfaces for SharpLearning.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.26.6.1</Version>
-    <AssemblyVersion>0.26.6.1</AssemblyVersion>
-    <FileVersion>0.26.6.1</FileVersion>
+	  <Version>0.26.7.0</Version>
+    <AssemblyVersion>0.26.7.0</AssemblyVersion>
+    <FileVersion>0.26.7.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpLearning.CrossValidation.Test.Properties;
@@ -19,9 +20,8 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
             var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
             var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
             var targets = parser.EnumerateRows(targetName).ToF64Vector();
-            var initialTrainingSize = 5;
-
-            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize);
+            
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize: 5);
 
             var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
             var timeSeriesTargets = sut.GetValidationTargets(targets);
@@ -30,6 +30,25 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
             var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
 
             Assert.AreEqual(0.097833163747046217, error, 0.00001);
+        }
+
+        [TestMethod]
+        public void TimeSeriesCrossValidation_Validate_MaxTrainingSetSize()
+        {
+            var targetName = "T";
+            var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
+            var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
+            var targets = parser.EnumerateRows(targetName).ToF64Vector();
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize: 5, maxTrainingSetSize: 10);
+
+            var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
+            var timeSeriesTargets = sut.GetValidationTargets(targets);
+
+            var metric = new MeanSquaredErrorRegressionMetric();
+            var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
+
+            Assert.AreEqual(0.01203243827648333, error, 0.00001);
         }
 
         [TestMethod]
@@ -44,6 +63,27 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
             var expected = targets.Skip(initialTrainingSize).ToArray();
 
             CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TimeSeriesCrossValidation_InitialTrainingSize_Is_Zero()
+        {
+            new TimeSeriesCrossValidation<double>(initialTrainingSize: 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TimeSeriesCrossValidation_MaxTrainingSetSize_Is_Smaller_Than_Zero()
+        {
+            new TimeSeriesCrossValidation<double>(initialTrainingSize: 5, maxTrainingSetSize: -1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TimeSeriesCrossValidation_InitialTrainingSize_Is_Larger_Than_MaxTrainingSetSize()
+        {
+            new TimeSeriesCrossValidation<double>(initialTrainingSize: 5, maxTrainingSetSize: 4);
         }
     }
 }

--- a/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
@@ -1,0 +1,34 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpLearning.CrossValidation.Test.Properties;
+using SharpLearning.CrossValidation.TimeSeries;
+using SharpLearning.DecisionTrees.Learners;
+using SharpLearning.InputOutput.Csv;
+using SharpLearning.Metrics.Regression;
+
+namespace SharpLearning.CrossValidation.Test.TimeSeries
+{
+    [TestClass]
+    public class TimeSeriesCrossValidationTest
+    {
+        [TestMethod]
+        public void TimeSeriesCrossValidation_Validate()
+        {
+            var targetName = "T";
+            var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
+            var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
+            var targets = parser.EnumerateRows(targetName).ToF64Vector();
+            var initialTrainingSize = 5;
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize);
+            var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
+            var timeSeriesTargets = targets.Skip(initialTrainingSize).ToArray();
+
+            var metric = new MeanSquaredErrorRegressionMetric();
+            var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
+
+            Assert.AreEqual(0.097833163747046217, error, 0.00001);
+        }
+    }
+}

--- a/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
@@ -92,13 +92,28 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
         [TestMethod]
         public void TimeSeriesCrossValidation_GetValidationTargets()
         {
-            var targets = Enumerable.Range(0, 100).Select(v => (double)v).ToArray();
+            var random = new Random(23);
+            var targets = Enumerable.Range(0, 100).Select(v => (double)random.Next()).ToArray();
             var initialTrainingSize = 5;
 
             var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize);
 
             var actual = sut.GetValidationTargets(targets);
             var expected = targets.Skip(initialTrainingSize).ToArray();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TimeSeriesCrossValidation_GetValidationIndices()
+        {
+            var targets = Enumerable.Range(0, 100).Select(v => (double)v).ToArray();
+            var initialTrainingSize = 5;
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize);
+
+            var actual = sut.GetValidationIndices(targets);
+            var expected = targets.Skip(initialTrainingSize).Select(v => (int)v).ToArray();
 
             CollectionAssert.AreEqual(expected, actual);
         }

--- a/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
@@ -22,13 +22,28 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
             var initialTrainingSize = 5;
 
             var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize);
+
             var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
-            var timeSeriesTargets = targets.Skip(initialTrainingSize).ToArray();
+            var timeSeriesTargets = sut.GetValidationTargets(targets);
 
             var metric = new MeanSquaredErrorRegressionMetric();
             var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
 
             Assert.AreEqual(0.097833163747046217, error, 0.00001);
+        }
+
+        [TestMethod]
+        public void TimeSeriesCrossValidation_GetValidationTargets()
+        {
+            var targets = Enumerable.Range(0, 100).Select(v => (double)v).ToArray();
+            var initialTrainingSize = 5;
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize);
+
+            var actual = sut.GetValidationTargets(targets);
+            var expected = targets.Skip(initialTrainingSize).ToArray();
+
+            CollectionAssert.AreEqual(expected, actual);
         }
     }
 }

--- a/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
@@ -67,6 +67,34 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
+        public void TimeSeriesCrossValidation_Validate_Observations_And_Targets_Length_Does_Not_Match()
+        {
+            var targetName = "T";
+            var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
+            var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
+            var targets = parser.EnumerateRows(targetName).Take(100).ToF64Vector();
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize: 5);
+
+            var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TimeSeriesCrossValidation_Validate_InitialTrainingSize_Is_Larger_Than_Obsevations_Length()
+        {
+            var targetName = "T";
+            var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
+            var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
+            var targets = parser.EnumerateRows(targetName).ToF64Vector();
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize: 300);
+
+            var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
         public void TimeSeriesCrossValidation_InitialTrainingSize_Is_Zero()
         {
             new TimeSeriesCrossValidation<double>(initialTrainingSize: 0);

--- a/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/TimeSeries/TimeSeriesCrossValidationTest.cs
@@ -31,7 +31,7 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
 
             Assert.AreEqual(0.097833163747046217, error, 0.00001);
         }
-
+        
         [TestMethod]
         public void TimeSeriesCrossValidation_Validate_MaxTrainingSetSize()
         {
@@ -49,6 +49,44 @@ namespace SharpLearning.CrossValidation.Test.TimeSeries
             var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
 
             Assert.AreEqual(0.01203243827648333, error, 0.00001);
+        }
+
+        [TestMethod]
+        public void TimeSeriesCrossValidation_Validate_RetrainInterval()
+        {
+            var targetName = "T";
+            var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
+            var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
+            var targets = parser.EnumerateRows(targetName).ToF64Vector();
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize: 5, retrainInterval: 5);
+
+            var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
+            var timeSeriesTargets = sut.GetValidationTargets(targets);
+
+            var metric = new MeanSquaredErrorRegressionMetric();
+            var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
+
+            Assert.AreEqual(0.09701682683694364, error, 0.00001);
+        }
+
+        [TestMethod]
+        public void TimeSeriesCrossValidation_Validate_MaxTrainingSetSize_And_RetrainInterval()
+        {
+            var targetName = "T";
+            var parser = new CsvParser(() => new StringReader(Resources.DecisionTreeData));
+            var observations = parser.EnumerateRows(v => !v.Contains(targetName)).ToF64Matrix();
+            var targets = parser.EnumerateRows(targetName).ToF64Vector();
+
+            var sut = new TimeSeriesCrossValidation<double>(initialTrainingSize: 5, maxTrainingSetSize: 30, retrainInterval: 5);
+
+            var timeSeriesPredictions = sut.Validate(new RegressionDecisionTreeLearner(), observations, targets);
+            var timeSeriesTargets = sut.GetValidationTargets(targets);
+
+            var metric = new MeanSquaredErrorRegressionMetric();
+            var error = metric.Error(timeSeriesTargets, timeSeriesPredictions);
+
+            Assert.AreEqual(0.11347313000447182, error, 0.00001);
         }
 
         [TestMethod]

--- a/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
+++ b/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SharpLearning.Common.Interfaces;
+using SharpLearning.Containers.Matrices;
+
+namespace SharpLearning.CrossValidation.TimeSeries
+{
+    /// <summary>
+    /// Time series cross-validation. Based on rolling validation using the original order of the data.
+    /// Using the specified initial size of the training set, a model is trained. 
+    /// The model predicts the first observation following the training data. 
+    /// Following, this data point is included in the training and a new model is trained,
+    /// which predict the next observation. This continous until all observations following the initial training size,
+    /// has been validated.
+    /// </summary>
+    /// <typeparam name="TPrediction"></typeparam>
+    public sealed class TimeSeriesCrossValidation<TPrediction>
+    {
+        readonly int m_initialTrainingSize;
+
+        /// <summary>
+        /// Time series cross-validation. Based on rolling validation.
+        /// </summary>
+        /// <param name="initialTrainingSize">The initial size of the training set.</param>
+        public TimeSeriesCrossValidation(int initialTrainingSize)
+        {
+            if (initialTrainingSize <= 0) throw new ArgumentException($"initialTrainingSize much be larger than 0, was {initialTrainingSize}");
+            m_initialTrainingSize = initialTrainingSize;
+        }
+
+        /// <summary>
+        /// Time series cross-validation. Based on rolling validation using the original order of the data.
+        /// Using the specified initial size of the training set, a model is trained. 
+        /// The model predicts the first observation following the training data. 
+        /// Following, this data point is included in the training and a new model is trained,
+        /// which predict the next observation. This continous until all observations following the initial training size,
+        /// has been validated.
+        /// </summary>
+        /// <param name="learner"></param>
+        /// <param name="observations"></param>
+        /// <param name="targets"></param>
+        /// <returns>The validated predictions, following the initial training size</returns>
+        public TPrediction[] Validate(IIndexedLearner<TPrediction> learner, F64Matrix observations, double[] targets)
+        {
+            if (observations.RowCount != targets.Length)
+            { throw new ArgumentException($"observation row count {observations.RowCount} must match target length {targets.Length}"); }
+
+            if (m_initialTrainingSize >= observations.RowCount)
+            { throw new ArgumentException($"observation row count {observations.RowCount} is smaller than initial training size {m_initialTrainingSize}"); }
+
+            var trainingIndices = Enumerable.Range(0, m_initialTrainingSize).ToArray();
+            var predictionLength = targets.Length - trainingIndices.Length;
+            var predictions = new TPrediction[predictionLength];
+
+            var observation = new double[observations.ColumnCount];
+            var currentObservationIndex = trainingIndices.Length;
+
+            for (int i = 0; i < predictions.Length; i++)
+            {
+                var model = learner.Learn(observations, targets, trainingIndices);
+                observations.Row(currentObservationIndex, observation);
+                predictions[i] = model.Predict(observation);
+
+                currentObservationIndex++;
+                trainingIndices = Enumerable.Range(0, currentObservationIndex).ToArray();
+            }
+
+            return predictions;
+        }
+    }
+}

--- a/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
+++ b/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
@@ -104,13 +104,25 @@ namespace SharpLearning.CrossValidation.TimeSeries
 
         /// <summary>
         /// Takes as input the original array of targets used as input for the validation,
-        /// and returns the subset of targets corresponding to the validation prediction.
+        /// and returns the subset of targets corresponding to the validation predictions.
         /// </summary>
         /// <param name="targets">The original array of targets used as input for the validation</param>
-        /// <returns>The subset of targets corresponding to the validation prediction</returns>
+        /// <returns>The subset of targets corresponding to the validation predictions</returns>
         public double[] GetValidationTargets(double[] targets)
         {
             return targets.Skip(m_initialTrainingSize).ToArray();
+        }
+
+        /// <summary>
+        /// Takes as input the original array of targets used as input for the validation,
+        /// and returns the indices used for the validation predictions.
+        /// </summary>
+        /// <param name="targets">The original array of targets used as input for the validation</param>
+        /// <returns>The subset of indices used for the validation predictions</returns>
+        public int[] GetValidationIndices(double[] targets)
+        {
+            return Enumerable.Range(0, targets.Length)
+                .Skip(m_initialTrainingSize).ToArray();
         }
     }
 }

--- a/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
+++ b/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using SharpLearning.Common.Interfaces;
 using SharpLearning.Containers.Matrices;
 

--- a/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
+++ b/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
@@ -23,25 +23,20 @@ namespace SharpLearning.CrossValidation.TimeSeries
         /// Time series cross-validation. Based on rolling validation.
         /// </summary>
         /// <param name="initialTrainingSize">The initial size of the training set.</param>
-        /// <param name="maxTrainingSetSize">The maximum size of the training set. When the max is reached, 
-        /// the training set size will be kept constant, but move forward in time, 
-        /// using the data closest to the test period as training data. Default is 0, which indicate no maximum size</param>
+        /// <param name="maxTrainingSetSize">The maximum size of the training set. Default is 0, which indicate no maximum size, 
+        /// resulting in an expanding training interval. If a max is chosen, and the max size is reached, 
+        /// this will result in a sliding training interval, moving forward in time, 
+        /// always using the data closest to the test period as training data. </param>
         public TimeSeriesCrossValidation(int initialTrainingSize, int maxTrainingSetSize = 0)
         {
             if (initialTrainingSize <= 0)
-            {
-                throw new ArgumentException($"{nameof(initialTrainingSize)} much be larger than 0, was {initialTrainingSize}");
-            }
+            { throw new ArgumentException($"{nameof(initialTrainingSize)} much be larger than 0, was {initialTrainingSize}"); }
 
             if (maxTrainingSetSize < 0)
-            {
-                throw new ArgumentException($"{nameof(maxTrainingSetSize)} much be larger than 0, was {maxTrainingSetSize}");
-            }
+            { throw new ArgumentException($"{nameof(maxTrainingSetSize)} much be larger than 0, was {maxTrainingSetSize}"); }
 
             if ((maxTrainingSetSize != 0) && (initialTrainingSize > maxTrainingSetSize))
-            {
-                throw new ArgumentException($"{nameof(initialTrainingSize)} = {initialTrainingSize} is larger than {nameof(maxTrainingSetSize)} = {maxTrainingSetSize}");
-            }
+            { throw new ArgumentException($"{nameof(initialTrainingSize)} = {initialTrainingSize} is larger than {nameof(maxTrainingSetSize)} = {maxTrainingSetSize}"); }
 
             m_initialTrainingSize = initialTrainingSize;
             m_maxTrainingSetSize = maxTrainingSetSize;

--- a/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
+++ b/src/SharpLearning.CrossValidation/TimeSeries/TimeSeriesCrossValidation.cs
@@ -67,5 +67,16 @@ namespace SharpLearning.CrossValidation.TimeSeries
 
             return predictions;
         }
+
+        /// <summary>
+        /// Takes as input the original array of targets used as input for the validation,
+        /// and returns the subset of targets corresponding to the validation prediction.
+        /// </summary>
+        /// <param name="targets">The original array of targets used as input for the validation</param>
+        /// <returns>The subset of targets corresponding to the validation prediction</returns>
+        public double[] GetValidationTargets(double[] targets)
+        {
+            return targets.Skip(m_initialTrainingSize).ToArray();
+        }
     }
 }

--- a/src/SharpLearning.Optimization/SharpLearning.Optimization.csproj
+++ b/src/SharpLearning.Optimization/SharpLearning.Optimization.csproj
@@ -9,7 +9,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>SharpLearning.Optimization</PackageId>
     <Description>Provides optimization algorithms.</Description>
-    <PackageTags>optimization machinelearning grid search random particle swarm neldermead nelder mead smo machine learning</PackageTags>
+    <PackageTags>optimization grid search random particle swarm neldermead nelder mead bayesian bayesianoptimization machine learning machinelearning</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
With most time series data, it is not possible to use traditional cross-validation methods, like the CrossValidators available in SharpLearning. The reason for this is, that shuffling the data will result in the learner and model using future data to predict past observations.
While it is possible to use the NoShuffleTrainingTestSplitter to create a single split without chainging the order, this will limit the size of test set and for smaller datasets reduce the robustness of the test set error/generalization error.

For this reason, this pull request introduces the TimeSeriesCrossValidation<T> class. Time series cross-validation is based on rolling validation, where the original order of the data is kept, and new observations in the test interval are predicted as hold-out samples and following included in the model one at a time. A nice illustration of this can be found here: [Cross-validation for time series](https://robjhyndman.com/hyndsight/tscv/). 

The TimeSeriesCrossValidation<T> class supports the following features:
 - InitialTrainingSetSize: Specify how much data the initial learner/model should use.
 - maxTrainingSetSize: Specify a max size for the training interval. If no max size is specified, this will correspond to an expading training interval. If a max is specified, this will correspond to a sliding training interval.
 - retrainInterval: Specify how often the model being validated should be retrained. If no interval is specified, the model will be retrained each time a new time step is predicted and included. If an interval is specified, the model will only be retrained at the specified interval and the existing model will be used for validation predictions inbetween the retrain intervals.

More information can be found in the documentation of the code and the unit tests.

A short example showing how to measure the mean square error using The TimeSeriesCrossValidation<T>class:

```c#
var tsCv = new TimeSeriesCrossValidation<double>(initialTrainingSize: 30);

// Calculate the validated predictions.
var timeSeriesPredictions = tsCv.Validate(new RegressionDecisionTreeLearner(), observations, targets);
// Get the targets corresponding to the validation predictions. 
var timeSeriesTargets = tsCv.GetValidationTargets(targets);

// Measure the mean square error
var metric = new MeanSquaredErrorRegressionMetric();
var mse = metric.Error(timeSeriesTargets, timeSeriesPredictions);
```


 