### PR TITLE
Add proper optimizer seeding to all optimizers in SharpLearning.Optimization

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.27.1.0</Version>
-    <AssemblyVersion>0.27.1.0</AssemblyVersion>
-    <FileVersion>0.27.1.0</FileVersion>
+	  <Version>0.28.0.0</Version>
+    <AssemblyVersion>0.28.0.0</AssemblyVersion>
+    <FileVersion>0.28.0.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -21,12 +21,12 @@ namespace SharpLearning.Optimization.Test
             var sut = new BayesianOptimizer(parameters, 100, 5, 1);
             var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(actual.Error, -0.73736717818644282, 0.0001);
+            Assert.AreEqual(actual.Error, -0.74765422244251278, 0.0001);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], 7.8124302242940438, m_delta);
-            Assert.AreEqual(actual.ParameterSet[1], -3.2319937242343988, m_delta);
-            Assert.AreEqual(actual.ParameterSet[2], 0.34947285910578074, m_delta);
+            Assert.AreEqual(actual.ParameterSet[0], -5.0065683270835173, m_delta);
+            Assert.AreEqual(actual.ParameterSet[1], -9.67008227467075, m_delta);
+            Assert.AreEqual(actual.ParameterSet[2], -0.24173704452893574, m_delta);
         }
 
         [TestMethod]
@@ -42,8 +42,8 @@ namespace SharpLearning.Optimization.Test
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 37.524597457388694 }, 110.80326835639002),
-                new OptimizerResult(new double[] { 98.240981063917729 }, 150512.62292441679)
+                new OptimizerResult(new double[] { 42.323589763754789 }, 981.97873691815118),
+                new OptimizerResult(new double[] { 99.110398813667885 }, 154864.41962974239)
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, m_delta);

--- a/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
@@ -19,12 +19,12 @@ namespace SharpLearning.Optimization.Test
             var sut = new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
             var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(actual.Error, -0.99999927563662372, 0.0000001);
+            Assert.AreEqual(actual.Error, -0.99999949547279676, 0.0000001);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], 1.5710337846223761, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[1], 3.1421855980282225, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[2], 5.203790999662519E-07, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, 0.0000001);
         }
 
         [TestMethod]

--- a/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
@@ -19,12 +19,12 @@ namespace SharpLearning.Optimization.Test
             var sut = new ParticleSwarmOptimizer(parameters, 100);
             var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(actual.Error, -0.45484916939206588, 0.0000001);
+            Assert.AreEqual(actual.Error, -0.64324321766401094, 0.0000001);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -10, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[1], -10, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[2], 0.0035692182837614439, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[0], -4.92494268653156, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[1], 10, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[2], -0.27508308116943514, 0.0000001);
         }
 
         [TestMethod]
@@ -40,8 +40,8 @@ namespace SharpLearning.Optimization.Test
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 37.804275358363732 }, 109.68474734728727),
-                new OptimizerResult(new double[] { 35.942821697748165 }, 238.00642904844648)
+                new OptimizerResult(new double[] { 37.660092259635064 }, 109.45936368750877),
+                new OptimizerResult(new double[] { 39.038272502859328 }, 181.43166846962754)
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);

--- a/src/SharpLearning.Optimization/BayesianOptimizer.cs
+++ b/src/SharpLearning.Optimization/BayesianOptimizer.cs
@@ -27,6 +27,7 @@ namespace SharpLearning.Optimization
         readonly int m_numberOfStartingPoints;
         readonly int m_numberOfCandidatesEvaluatedPrIteration;
         readonly IParameterSampler m_sampler;
+        readonly Random m_random;
 
         readonly List<double[]> m_previousParameterSets;
         readonly List<double> m_previousParameterSetScores;
@@ -70,16 +71,28 @@ namespace SharpLearning.Optimization
             m_numberOfStartingPoints = numberOfStartingPoints;
             m_numberOfCandidatesEvaluatedPrIteration = numberOfCandidatesEvaluatedPrIteration;
 
-            m_sampler = new RandomUniform(seed);
+            m_random = new Random(seed);
+
+            // Use member to seed the random uniform sampler.
+            m_sampler = new RandomUniform(m_random.Next());
             
             // Hyper parameters for regression extra trees learner. These are based on the values suggested in http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf.
             // However, according to the author Frank Hutter, the hyper parameters for the forest model should not matter that much.
-            m_learner = new RegressionExtremelyRandomizedTreesLearner(30, 10, 2000, parameters.Length, 1e-6, 1.0, 42, false);
+            m_learner = new RegressionExtremelyRandomizedTreesLearner(trees: 30, 
+                minimumSplitSize: 10, 
+                maximumTreeDepth: 2000, 
+                featuresPrSplit: parameters.Length, 
+                minimumInformationGain: 1e-6, 
+                subSampleRatio: 1.0, 
+                seed: m_random.Next(), // Use member to seed the random uniform sampler.
+                runParallel: false);
 
-            // optimizer for finding maximum expectation (most promissing hyper parameters) from extra trees model.
-            m_maximizer = new RandomSearchOptimizer(m_parameters, 1000, 42, false);
+            // Optimizer for finding maximum expectation (most promissing hyper parameters) from extra trees model.
+            m_maximizer = new RandomSearchOptimizer(m_parameters, iterations: 1000, 
+                seed: m_random.Next(), // Use member to seed the random uniform sampler.
+                runParallel: false);
 
-            // acquisition function to maximize,
+            // Acquisition function to maximize.
             m_acquisitionFunc = AcquisitionFunctions.ExpectedImprovement;
         }
 
@@ -114,21 +127,32 @@ namespace SharpLearning.Optimization
             if (previousParameterSetScores.Count < 2 || previousParameterSets.Count < 2)
             { throw new ArgumentException("previousParameterSets length and previousResults length must be at least 2 and was: " + previousParameterSetScores.Count); }
 
-
             m_parameters = parameters;
             m_maxIterations = maxIterations;
             m_numberOfCandidatesEvaluatedPrIteration = numberOfCandidatesEvaluatedPrIteration;
 
-            m_sampler = new RandomUniform(seed);
+            m_random = new Random(seed);
+
+            // Use member to seed the random uniform sampler.
+            m_sampler = new RandomUniform(m_random.Next());
 
             // Hyper parameters for regression extra trees learner. These are based on the values suggested in http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf.
             // However, according to the author Frank Hutter, the hyper parameters for the forest model should not matter that much.
-            m_learner = new RegressionExtremelyRandomizedTreesLearner(30, 10, 2000, parameters.Length, 1e-6, 1.0, 42, false);
+            m_learner = new RegressionExtremelyRandomizedTreesLearner(trees: 30,
+                minimumSplitSize: 10,
+                maximumTreeDepth: 2000,
+                featuresPrSplit: parameters.Length,
+                minimumInformationGain: 1e-6,
+                subSampleRatio: 1.0,
+                seed: m_random.Next(), // Use member to seed the random uniform sampler.
+                runParallel: false);
 
-            // optimizer for finding maximum expectation (most promissing hyper parameters) from random forest model
-            m_maximizer = new RandomSearchOptimizer(m_parameters, 1000, 42, false);
+            // Optimizer for finding maximum expectation (most promissing hyper parameters) from extra trees model.
+            m_maximizer = new RandomSearchOptimizer(m_parameters, iterations: 1000,
+                seed: m_random.Next(), // Use member to seed the random uniform sampler.
+                runParallel: false);
 
-            // acquisition function to maximize,
+            // Acquisition function to maximize.
             m_acquisitionFunc = AcquisitionFunctions.ExpectedImprovement;
 
             m_previousParameterSets = previousParameterSets;

--- a/src/SharpLearning.Optimization/GlobalizedBoundedNelderMeadOptimizer.cs
+++ b/src/SharpLearning.Optimization/GlobalizedBoundedNelderMeadOptimizer.cs
@@ -31,7 +31,7 @@ namespace SharpLearning.Optimization
         readonly IParameterSampler m_sampler;
         readonly int m_maxFunctionEvaluations;
         int m_totalFunctionEvaluations;
-        
+
         /// <summary>
         /// Globalized bounded Nelder-Mead method. This version of Nelder-Mead optimization 
         /// avoids some of the shortcommings the standard implementation. 
@@ -52,9 +52,10 @@ namespace SharpLearning.Optimization
         /// <param name="gamma">Coefficient for expansion part of the algorithm (default is 2)</param>
         /// <param name="rho">Coefficient for contraction part of the algorithm (default is -0.5)</param>
         /// <param name="sigma">Coefficient for shrink part of the algorithm (default is 0.5)</param>
+        /// <param name="seed">Seed for random restarts</param>
         public GlobalizedBoundedNelderMeadOptimizer(ParameterBounds[] parameters, int maxRestarts=8, double noImprovementThreshold = 0.001, 
             int maxIterationsWithoutImprovement = 5, int maxIterationsPrRestart = 0, int maxFunctionEvaluations = 0,
-            double alpha = 1, double gamma = 2, double rho = -0.5, double sigma = 0.5)
+            double alpha = 1, double gamma = 2, double rho = -0.5, double sigma = 0.5, int seed = 324)
         {
             if (parameters == null) { throw new ArgumentNullException("parameters"); }
             if (maxIterationsWithoutImprovement <= 0) { throw new ArgumentNullException("maxIterationsWithoutImprovement must be at least 1"); }
@@ -71,8 +72,10 @@ namespace SharpLearning.Optimization
             m_maxIterationsWithoutImprovement = maxIterationsWithoutImprovement;
             m_maxFunctionEvaluations = maxFunctionEvaluations;
 
-            m_random = new Random(324);
-            m_sampler = new RandomUniform();
+            m_random = new Random(seed);
+
+            // Use member to seed the random uniform sampler.
+            m_sampler = new RandomUniform(m_random.Next());
         }
         /// <summary>
         /// Optimization using Globalized bounded Nelder-Mead method.

--- a/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
+++ b/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
@@ -49,7 +49,9 @@ namespace SharpLearning.Optimization
             m_c2 = c2;
             
             m_random = new Random(seed);
-            m_sampler = new RandomUniform();
+            
+            // Use member to seed the random uniform sampler.
+            m_sampler = new RandomUniform(m_random.Next());
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request will add proper seeding to all optimizer algorithms in `SharpLearning.Optimization`. The technique used is a single seed is set through the constructor, this seed is used to create a `random` generator, which will then create seeds for all underlying algorithms used in the given optimizer.

Note, that since this PR will change default seeding of the optimizers, the default behavior of the optimizers will not be the same as before this addition.

This should solve issue #69 . 