### PR TITLE
0.29.1: Rename logarithmic transform to Log10 transform, and release contribution of parallel ParticleSwarm and parallel GlobalizedBoundedNelderMeadOptimizer.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.29.0.0</Version>
-    <AssemblyVersion>0.29.0.0</AssemblyVersion>
-    <FileVersion>0.29.0.0</FileVersion>
+	  <Version>0.29.1.0</Version>
+    <AssemblyVersion>0.29.1.0</AssemblyVersion>
+    <FileVersion>0.29.1.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
@@ -20,7 +20,12 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
-            var sut = maxDegreeOfParallelism.HasValue ? new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10, 
+                    maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
+                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
+
             var actual = sut.OptimizeBest(Minimize);
 
             Assert.AreEqual(actual.Error, -0.99999949547279676, 0.0000001);
@@ -42,7 +47,12 @@ namespace SharpLearning.Optimization.Test
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
-            var sut = maxDegreeOfParallelism.HasValue ? new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10, 
+                    maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
+                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
+
             var results = sut.Optimize(Minimize2);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 

--- a/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
@@ -16,7 +16,11 @@ namespace SharpLearning.Optimization.Test
         public void GridSearchOptimizer_OptimizeBest(int? maxDegreeOfParallelism)
         {
             var parameters = new GridParameterSpec[] { new GridParameterSpec(10.0, 20.0, 30.0, 35.0, 37.5, 40.0, 50.0, 60.0) };
-            var sut = maxDegreeOfParallelism.HasValue ? new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : new GridSearchOptimizer(parameters);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
+                new GridSearchOptimizer(parameters);
+
             var actual = sut.OptimizeBest(Minimize);
 
             Assert.AreEqual(111.20889999999987, actual.Error, 0.00001);
@@ -31,7 +35,11 @@ namespace SharpLearning.Optimization.Test
         public void GridSearchOptimizer_Optimize(int? maxDegreeOfParallelism)
         {
             var parameters = new GridParameterSpec[] { new GridParameterSpec(10.0, 37.5) };
-            var sut = maxDegreeOfParallelism.HasValue ? new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : new GridSearchOptimizer(parameters);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
+                new GridSearchOptimizer(parameters);
+
             var actual = sut.Optimize(Minimize);
 
             var expected = new OptimizerResult[] 
@@ -69,5 +77,4 @@ namespace SharpLearning.Optimization.Test
             return new OptimizerResult(parameters, cost);
         }
     }
-
 }

--- a/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
@@ -14,7 +14,10 @@ namespace SharpLearning.Optimization.Test
         [DataRow(null)]
         public void GridSearchOptimizer_OptimizeBest(int? maxDegreeOfParallelism)
         {
-            var parameters = new GridParameterSpec[] { new GridParameterSpec(10.0, 20.0, 30.0, 35.0, 37.5, 40.0, 50.0, 60.0) };
+            var parameters = new GridParameterSpec[] 
+            {
+                new GridParameterSpec(10.0, 20.0, 30.0, 35.0, 37.5, 40.0, 50.0, 60.0)
+            };
 
             var sut = maxDegreeOfParallelism.HasValue ? 
                 new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
@@ -33,7 +36,10 @@ namespace SharpLearning.Optimization.Test
         [DataRow(null)]
         public void GridSearchOptimizer_Optimize(int? maxDegreeOfParallelism)
         {
-            var parameters = new GridParameterSpec[] { new GridParameterSpec(10.0, 37.5) };
+            var parameters = new GridParameterSpec[] 
+            {
+                new GridParameterSpec(10.0, 37.5)
+            };
 
             var sut = maxDegreeOfParallelism.HasValue ? 
                 new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 

--- a/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SharpLearning.Optimization.Test
 {

--- a/src/SharpLearning.Optimization.Test/ParameterBoundsTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParameterBoundsTest.cs
@@ -10,7 +10,9 @@ namespace SharpLearning.Optimization.Test
         [TestMethod]
         public void ParameterBounds_NextValue()
         {
-            var sut = new MinMaxParameterSpec(min: 20, max: 200, transform: Transform.Linear);
+            var sut = new MinMaxParameterSpec(min: 20, max: 200, 
+                transform: Transform.Linear);
+
             var sampler = new RandomUniform(seed: 32);
 
             var actual = new double[10];
@@ -19,7 +21,20 @@ namespace SharpLearning.Optimization.Test
                 actual[i] = sut.SampleValue(sampler: sampler);
             }
 
-            var expected = new double[] { 99.8935983236384, 57.2098020451189, 44.4149092419142, 89.9002946307418, 137.643828772774, 114.250629522954, 63.8914499915631, 109.294177409864, 188.567149950455, 33.2731248034505 };
+            var expected = new double[] 
+            {
+                99.8935983236384,
+                57.2098020451189,
+                44.4149092419142,
+                89.9002946307418,
+                137.643828772774,
+                114.250629522954,
+                63.8914499915631,
+                109.294177409864,
+                188.567149950455,
+                33.2731248034505
+            };
+
             Assert.AreEqual(expected.Length, actual.Length);
             for (int i = 0; i < expected.Length; i++)
             {
@@ -45,7 +60,8 @@ namespace SharpLearning.Optimization.Test
         [ExpectedException(typeof(ArgumentNullException))]
         public void ParameterBounds_Throw_On_Transform_Is_Null()
         {
-            new MinMaxParameterSpec(min: 10, max: 30, transform: null, parameterType: ParameterType.Continuous);
+            new MinMaxParameterSpec(min: 10, max: 30, transform: null, 
+                parameterType: ParameterType.Continuous);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
@@ -20,7 +20,11 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
-            var sut = maxDegreeOfParallelism.HasValue ? new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : new ParticleSwarmOptimizer(parameters, 100);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
+                new ParticleSwarmOptimizer(parameters, 100);
+
             var actual = sut.OptimizeBest(Minimize);
 
             Assert.AreEqual(actual.Error, -0.64324321766401094, 0.0000001);
@@ -42,8 +46,13 @@ namespace SharpLearning.Optimization.Test
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
-            var sut = maxDegreeOfParallelism.HasValue ? new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : new ParticleSwarmOptimizer(parameters, 100);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
+                new ParticleSwarmOptimizer(parameters, 100);
+
             var results = sut.Optimize(Minimize2);
+
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]

--- a/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
@@ -18,7 +18,11 @@ namespace SharpLearning.Optimization.Test
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
-            var sut = maxDegreeOfParallelism.HasValue ? new RandomSearchOptimizer(parameters, 100, 42, true, maxDegreeOfParallelism.Value) : new RandomSearchOptimizer(parameters, 100);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new RandomSearchOptimizer(parameters, 100, 42, true, maxDegreeOfParallelism.Value) : 
+                new RandomSearchOptimizer(parameters, 100);
+
             var actual = sut.OptimizeBest(Minimize);
 
             Assert.AreEqual(110.67173923600831, actual.Error, 0.00001);
@@ -36,7 +40,11 @@ namespace SharpLearning.Optimization.Test
             {
                 new MinMaxParameterSpec(10.0, 37.5, Transform.Linear)
             };
-            var sut = maxDegreeOfParallelism.HasValue ? new RandomSearchOptimizer(parameters, 2, 42, true, maxDegreeOfParallelism.Value) : new RandomSearchOptimizer(parameters, 2);
+
+            var sut = maxDegreeOfParallelism.HasValue ? 
+                new RandomSearchOptimizer(parameters, 2, 42, true, maxDegreeOfParallelism.Value) : 
+                new RandomSearchOptimizer(parameters, 2);
+
             var actual = sut.Optimize(Minimize);
 
             var expected = new OptimizerResult[]
@@ -74,5 +82,4 @@ namespace SharpLearning.Optimization.Test
             return new OptimizerResult(parameters, cost);
         }
     }
-
 }

--- a/src/SharpLearning.Optimization.Test/Transforms/ExponentialAverageTransformTest.cs
+++ b/src/SharpLearning.Optimization.Test/Transforms/ExponentialAverageTransformTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpLearning.Optimization.ParameterSamplers;
 using SharpLearning.Optimization.Transforms;

--- a/src/SharpLearning.Optimization.Test/Transforms/Log10TransformTest.cs
+++ b/src/SharpLearning.Optimization.Test/Transforms/Log10TransformTest.cs
@@ -6,12 +6,12 @@ using SharpLearning.Optimization.Transforms;
 namespace SharpLearning.Optimization.Test.Transforms
 {
     [TestClass]
-    public class LogarithmicTransformTest
+    public class Log10TransformTest
     {
         [TestMethod]
-        public void LogarithmicTransform_Transform()
+        public void Log10Transform_Transform()
         {
-            var sut = new LogarithmicTransform();
+            var sut = new Log10Transform();
             var sampler = new RandomUniform(seed: 32);
 
             var actual = new double[10];
@@ -31,9 +31,9 @@ namespace SharpLearning.Optimization.Test.Transforms
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void LogarithmicTransform_Throw_On_Min_equal_Zero()
+        public void Log10Transform_Throw_On_Min_equal_Zero()
         {
-            var sut = new LogarithmicTransform();
+            var sut = new Log10Transform();
             var sampler = new RandomUniform(seed: 32);
             sut.Transform(min: 0, max: 1,
                 parameterType: ParameterType.Continuous, sampler: sampler);
@@ -41,9 +41,9 @@ namespace SharpLearning.Optimization.Test.Transforms
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void LogarithmicTransform_Throw_On_Max_equal_Zero()
+        public void Log10Transform_Throw_On_Max_equal_Zero()
         {
-            var sut = new LogarithmicTransform();
+            var sut = new Log10Transform();
             var sampler = new RandomUniform(seed: 32);
             sut.Transform(min: 0.01, max: 0,
                 parameterType: ParameterType.Continuous, sampler: sampler);
@@ -51,9 +51,9 @@ namespace SharpLearning.Optimization.Test.Transforms
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void LogarithmicTransform_Throw_On_Min_below_Zero()
+        public void Log10Transform_Throw_On_Min_below_Zero()
         {
-            var sut = new LogarithmicTransform();
+            var sut = new Log10Transform();
             var sampler = new RandomUniform(seed: 32);
             sut.Transform(min: -0.1, max: 1,
                 parameterType: ParameterType.Continuous, sampler: sampler);
@@ -61,9 +61,9 @@ namespace SharpLearning.Optimization.Test.Transforms
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
-        public void LogarithmicTransform_Throw_On_Max_below_Zero()
+        public void Log10Transform_Throw_On_Max_below_Zero()
         {
-            var sut = new LogarithmicTransform();
+            var sut = new Log10Transform();
             var sampler = new RandomUniform(seed: 32);
             sut.Transform(min: 0.1, max: -0.1,
                 parameterType: ParameterType.Continuous, sampler: sampler);

--- a/src/SharpLearning.Optimization.Test/Transforms/TransformFactoryTest.cs
+++ b/src/SharpLearning.Optimization.Test/Transforms/TransformFactoryTest.cs
@@ -12,8 +12,8 @@ namespace SharpLearning.Optimization.Test.Transforms
         {
             var linear = TransformFactory.Create(Transform.Linear);
             Assert.AreEqual(typeof(LinearTransform), linear.GetType());
-            var logarithmic = TransformFactory.Create(Transform.Linear);
-            Assert.AreEqual(typeof(LinearTransform), logarithmic.GetType());
+            var log10 = TransformFactory.Create(Transform.Log10);
+            Assert.AreEqual(typeof(Log10Transform), log10.GetType());
             var exponentialAverage = TransformFactory.Create(Transform.ExponentialAverage);
             Assert.AreEqual(typeof(ExponentialAverageTransform), exponentialAverage.GetType());
         }

--- a/src/SharpLearning.Optimization/GridSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/GridSearchOptimizer.cs
@@ -20,7 +20,7 @@ namespace SharpLearning.Optimization
         /// </summary>
         /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
         /// <param name="runParallel">Use multi threading to speed up execution (default is true)</param>
-        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is unlimited)</param>
+        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is -1 (unlimited))</param>
         public GridSearchOptimizer(IParameterSpec[] parameters, bool runParallel = true, int maxDegreeOfParallelism = -1)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));

--- a/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
+++ b/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
@@ -39,7 +39,7 @@ namespace SharpLearning.Optimization
         /// <param name="c1">Learning factor weighting local particle best solution. (default is 2)</param>
         /// <param name="c2">Learning factor weighting global best solution. (default is 2)</param>
         /// <param name="seed">Seed for the random initialization and velocity corrections</param>
-        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is unlimited)</param>
+        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is -1 (unlimited))</param>
         public ParticleSwarmOptimizer(IParameterSpec[] parameters, int maxIterations, int numberOfParticles = 10, double c1 = 2, double c2 = 2, int seed = 42, int maxDegreeOfParallelism = -1)
         {
             if (maxIterations <= 0) { throw new ArgumentException("maxIterations must be at least 1"); }

--- a/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
@@ -26,7 +26,7 @@ namespace SharpLearning.Optimization
         /// <param name="iterations">The number of iterations to perform</param>
         /// <param name="seed"></param>
         /// <param name="runParallel">Use multi threading to speed up execution (default is true)</param>
-        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is unlimited)</param>
+        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is -1 (unlimited))</param>
         public RandomSearchOptimizer(IParameterSpec[] parameters, int iterations, int seed=42, bool runParallel = true, int maxDegreeOfParallelism = -1)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));

--- a/src/SharpLearning.Optimization/Transform.cs
+++ b/src/SharpLearning.Optimization/Transform.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Logarithmic scale. For ranges with a large difference in numerical scale, like min: 0.0001 and max: 1.0.
         /// </summary>
-        Logarithmic,
+        Log10,
 
         /// <summary>
         /// ExponentialAverage scale. For ranges close to one, like min: 0.9 and max: 0.999.

--- a/src/SharpLearning.Optimization/Transforms/Log10Transform.cs
+++ b/src/SharpLearning.Optimization/Transforms/Log10Transform.cs
@@ -4,12 +4,12 @@ using SharpLearning.Optimization.ParameterSamplers;
 namespace SharpLearning.Optimization.Transforms
 {
     /// <summary>
-    /// Logarithmic scale. For ranges with a large difference in numerical scale, like min: 0.0001 and max: 1.0.
+    /// Transform to Log10 scale. For ranges with a large difference in numerical scale, like min: 0.0001 and max: 1.0.
     /// </summary>
-    public class LogarithmicTransform : ITransform
+    public class Log10Transform : ITransform
     {
         /// <summary>
-        /// Logarithmic scale. For ranges with a large difference in numerical scale, like min: 0.0001 and max: 1.0.
+        /// Transform to Log10 scale. For ranges with a large difference in numerical scale, like min: 0.0001 and max: 1.0.
         /// </summary>
         /// <param name="min"></param>
         /// <param name="max"></param>

--- a/src/SharpLearning.Optimization/Transforms/TransformFactory.cs
+++ b/src/SharpLearning.Optimization/Transforms/TransformFactory.cs
@@ -18,8 +18,8 @@ namespace SharpLearning.Optimization.Transforms
             {
                 case Transform.Linear:
                     return new LinearTransform();
-                case Transform.Logarithmic:
-                    return new LogarithmicTransform();
+                case Transform.Log10:
+                    return new Log10Transform();
                 case Transform.ExponentialAverage:
                     return new ExponentialAverageTransform();
                 default:


### PR DESCRIPTION
This pull request renames the `Logarithmic` transform to `Log10` transform. This should fix issue #93.

This pull request also releases the contributions made by @jameschch in pull request #95, which adds parallel execution to the following optimizers:

 - `ParticleSwarmOptimizer`
 - `GlobalizedBoundedNelderMeadOptimizer`

and adds selection of the degree of parallelism to:

 - `GridSearchOptimizer`
 - `RandomSearchOptimizer`