### PR TITLE
0.30.0: Optimizers Optimize method returns unfiltered results in chronological order

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.29.1.0</Version>
-    <AssemblyVersion>0.29.1.0</AssemblyVersion>
-    <FileVersion>0.29.1.0</FileVersion>
+	  <Version>0.30.0.0</Version>
+    <AssemblyVersion>0.30.0.0</AssemblyVersion>
+    <FileVersion>0.30.0.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -42,8 +42,8 @@ namespace SharpLearning.Optimization.Test
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 42.323589763754789 }, 981.97873691815118),
-                new OptimizerResult(new double[] { 99.110398813667885 }, 154864.41962974239)
+                new OptimizerResult(new double[] { 90.513222660177 }, 114559.431919558),
+                new OptimizerResult(new double[] { 24.204380402436 },   7601.008090362)
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, m_delta);
@@ -52,7 +52,6 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(expected.Last().Error, actual.Last().Error, m_delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), m_delta);
         }
-
 
         OptimizerResult Minimize(double[] x)
         {

--- a/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
@@ -57,8 +57,8 @@ namespace SharpLearning.Optimization.Test
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 37.660092259635064 }, 109.45936368750877),
-                new OptimizerResult(new double[] { 39.038272502859328 }, 181.43166846962754)
+                new OptimizerResult(new double[] { 38.1151505704492 }, 115.978346548015),
+                new OptimizerResult(new double[] { 37.2514904205637 }, 118.093289672808),
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
@@ -67,7 +67,6 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
             Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
         }
-
 
         OptimizerResult Minimize(double[] x)
         {

--- a/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
@@ -49,8 +49,8 @@ namespace SharpLearning.Optimization.Test
 
             var expected = new OptimizerResult[]
             {
-              new OptimizerResult(new double[] { 28.372927812567415 }, 3690.8111981874217),
-              new OptimizerResult(new double[] { 13.874950705270725 }, 23438.215764163542)
+                new OptimizerResult(new double[] { 13.8749507052707 }, 23438.2157641635),
+                new OptimizerResult(new double[] { 28.3729278125674 },  3690.81119818742),
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);

--- a/src/SharpLearning.Optimization/BayesianOptimizer.cs
+++ b/src/SharpLearning.Optimization/BayesianOptimizer.cs
@@ -173,11 +173,11 @@ namespace SharpLearning.Optimization
         /// <returns></returns>
         public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) =>
             // Return the best model found.
-            Optimize(functionToMinimize).First();
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         /// <summary>
         /// Optimization using Sequential Model-based optimization.
-        /// Returns the final results ordered from best to worst (minimized).
+        /// Returns all results, chronologically ordered. 
         /// </summary>
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
@@ -294,7 +294,7 @@ namespace SharpLearning.Optimization
                 results.Add(new OptimizerResult(parameterSets[i], parameterSetScores[i]));
             }
 
-            return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).ToArray();
+            return results.ToArray();
         }
 
         OptimizerResult[] FindNextCandidates(RegressionForestModel model, double bestScore)
@@ -309,7 +309,9 @@ namespace SharpLearning.Optimization
                     -m_acquisitionFunc(bestScore, p.Prediction, p.Variance));
             };
 
-            return m_maximizer.Optimize(minimize).Take(m_numberOfCandidatesEvaluatedPrIteration).ToArray();
+            return m_maximizer.Optimize(minimize)
+                .Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error)
+                .Take(m_numberOfCandidatesEvaluatedPrIteration).ToArray();
         }
 
         bool Equals(double[] p1, double[] p2)

--- a/src/SharpLearning.Optimization/GlobalizedBoundedNelderMeadOptimizer.cs
+++ b/src/SharpLearning.Optimization/GlobalizedBoundedNelderMeadOptimizer.cs
@@ -89,11 +89,12 @@ namespace SharpLearning.Optimization
         /// <returns></returns>
         public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) =>
             // Return the best model found.
-            Optimize(functionToMinimize).First();
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         /// <summary>
         /// Optimization using Globalized bounded Nelder-Mead method.
-        /// Returns the final results ordered from best to worst (minimized).
+        /// Returns all results, chronologically ordered. 
+        /// Note that the order of results might be affected if running parallel.
         /// </summary>
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
@@ -260,7 +261,7 @@ namespace SharpLearning.Optimization
                 }
             }
 
-            return allResults.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).ToArray();
+            return allResults.ToArray();
         }
 
         OptimizerResult EvaluateFunction(Func<double[], OptimizerResult> functionToMinimize, double[] parameters)

--- a/src/SharpLearning.Optimization/GridSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/GridSearchOptimizer.cs
@@ -36,11 +36,12 @@ namespace SharpLearning.Optimization
         /// <returns></returns>
         public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) =>
             // Return the best model found.
-            Optimize(functionToMinimize).First();
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         /// <summary>
         /// Simple grid search that tries all combinations of the provided parameters.
-        /// Returns all results ordered from best to worst (minimized).
+        /// Returns all results, chronologically ordered. 
+        /// Note that the order of results might be affected if running parallel.
         /// </summary>
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
@@ -72,7 +73,7 @@ namespace SharpLearning.Optimization
             }
 
             // return all results ordered
-            return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).ToArray();
+            return results.ToArray();
         }
 
         static double[][] CartesianProduct(IParameterSpec[] sequences)

--- a/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
+++ b/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
@@ -67,12 +67,10 @@ namespace SharpLearning.Optimization
         /// <returns></returns>
         public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) =>
             // Return the best model found.
-            Optimize(functionToMinimize).First();
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         /// <summary>
-        /// Optimization using swarm optimization.
-        /// Returns the final results ordered from best to worst (minimized).
-        /// </summary>
+        /// Optimization using swarm optimization. Returns results for all particles.
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
         public OptimizerResult[] Optimize(Func<double[], OptimizerResult> functionToMinimize)
@@ -160,7 +158,7 @@ namespace SharpLearning.Optimization
                 results.Add(new OptimizerResult(pBest[i], pBestScores[i]));
             }
 
-            return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).ToArray();
+            return results.ToArray();
         }
 
         void BoundCheck(double[] newValues, double[] maxValues, double[] minValues)

--- a/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
@@ -37,18 +37,19 @@ namespace SharpLearning.Optimization
         }
 
         /// <summary>
-        /// Random search optimizer initializes random parameters between min and max of the provided.
+        /// Random search optimizer initializes random parameters between min and max of the provided bounds.
         /// Returns the result which best minimizes the provided function.
         /// </summary>
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
         public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) =>
             // Return the best model found.
-            Optimize(functionToMinimize).First();
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         /// <summary>
-        /// Random search optimizer initializes random parameters between min and max of the provided
-        /// Returns all results ordered from best to worst (minimized).
+        /// Random search optimizer initializes random parameters between min and max of the provided bounds.
+        /// Returns all results, chronologically ordered. 
+        /// Note that the order of results might be affected if running parallel.
         /// </summary>
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
@@ -82,7 +83,7 @@ namespace SharpLearning.Optimization
 
 
             // return all results ordered
-            return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).ToArray();
+            return results.ToArray();
         }
 
 


### PR DESCRIPTION
The `Optimize ` method on the optimizers from `SharpLearning.Optimization` will now return all results, unfiltered and in chronological order. Before, the results would be filtered for `NaN` values and ordered from smallest to largest error. This change makes it easier to compare the iterations required to get a good solution between the optimizers. The `OptimizeBest` method, which returns the single best result from the optimizers, is unchanged and will provide exactly the same result as previously.

This is a potential breaking change, so if relaying on the order of the results from the `Optimize` method, these should now be sorted and/or filtered after the call to the optimizer. Like it is also done in the `OptimizeBest` method:

```CSharp
Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
```

Note, that the particle swarm optimizer only returns the latest result from each particle.