### PR TITLE
0.30.1.0: Add HyperbandOptimizer, and update test adapters

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.30.0.0</Version>
-    <AssemblyVersion>0.30.0.0</AssemblyVersion>
-    <FileVersion>0.30.0.0</FileVersion>
+	  <Version>0.30.1.0</Version>
+    <AssemblyVersion>0.30.1.0</AssemblyVersion>
+    <FileVersion>0.30.1.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.AdaBoost.Test/SharpLearning.AdaBoost.Test.csproj
+++ b/src/SharpLearning.AdaBoost.Test/SharpLearning.AdaBoost.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Containers.Test/SharpLearning.Containers.Test.csproj
+++ b/src/SharpLearning.Containers.Test/SharpLearning.Containers.Test.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
+++ b/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.DecisionTrees.Test/SharpLearning.DecisionTrees.Test.csproj
+++ b/src/SharpLearning.DecisionTrees.Test/SharpLearning.DecisionTrees.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Ensemble.Test/SharpLearning.Ensemble.Test.csproj
+++ b/src/SharpLearning.Ensemble.Test/SharpLearning.Ensemble.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.FeatureTransformations.Test/SharpLearning.FeatureTransformations.Test.csproj
+++ b/src/SharpLearning.FeatureTransformations.Test/SharpLearning.FeatureTransformations.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.GradientBoost.Test/SharpLearning.GradientBoost.Test.csproj
+++ b/src/SharpLearning.GradientBoost.Test/SharpLearning.GradientBoost.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.InputOutput.Test/SharpLearning.InputOutput.Test.csproj
+++ b/src/SharpLearning.InputOutput.Test/SharpLearning.InputOutput.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Metrics.Test/SharpLearning.Metrics.Test.csproj
+++ b/src/SharpLearning.Metrics.Test/SharpLearning.Metrics.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
+++ b/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
@@ -21,9 +21,9 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="3.17.0" />
     <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -85,8 +85,12 @@ namespace SharpLearning.Optimization.Test
             };
 
             // create random search optimizer
-            var maximunIterationsPrConfiguration = 40;
-            var optimizer = new HyperbandOptimizer(parameters, maximunIterationsPrConfiguration, eta: 3);
+            var maximunIterationsPrConfiguration = 81;
+
+            var optimizer = new HyperbandOptimizer(parameters, 
+                maximunIterationsPrConfiguration, 
+                eta: 3, 
+                skipLast: true);
 
             var timer = new Stopwatch();
 

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpLearning.CrossValidation.TrainingTestSplitters;
+using SharpLearning.GradientBoost.Learners;
+using SharpLearning.InputOutput.Csv;
+using SharpLearning.Metrics.Regression;
+
+namespace SharpLearning.Optimization.Test
+{
+    [TestClass]
+    public class HyperbandOptimizerTest
+    {
+        [TestMethod]
+        public void HyperbandOptimizer_Optimize()
+        {
+            // Use StreamReader(filepath) when running from filesystem
+            var parser = new CsvParser(() => new StreamReader(@"E:\Git\open-source\SharpLearning.Examples\src\Resources\winequality-white.csv"));
+            var targetName = "quality";
+
+            // read feature matrix
+            var observations = parser.EnumerateRows(c => c != targetName)
+                .ToF64Matrix();
+
+            // read regression targets
+            var targets = parser.EnumerateRows(targetName)
+                .ToF64Vector();
+
+            // creates training test splitter, 
+            // Since this is a regression problem, we use the random training/test set splitter.
+            // 30 % of the data is used for the test set. 
+            var splitter = new RandomTrainingTestIndexSplitter<double>(trainingPercentage: 0.7, seed: 24);
+
+            var trainingTestSplit = splitter.SplitSet(observations, targets);
+            var trainSet = trainingTestSplit.TrainingSet;
+            var testSet = trainingTestSplit.TestSet;
+
+            // since this is a regression problem we are using square error as metric
+            // for evaluating how well the model performs.
+            var metric = new MeanSquaredErrorRegressionMetric();
+
+            // Usually better results can be achieved by tuning a gradient boost learner
+
+            var numberOfFeatures = trainSet.Observations.ColumnCount;
+
+            // Parameter ranges for the optimizer
+            // best parameter to tune on random forest is featuresPrSplit.
+            var parameters = new IParameterSpec[]
+            {
+                //new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear), // iterations
+                new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10), // learning rate
+                new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear), // maximumTreeDepth
+                new MinMaxParameterSpec(min: 0.5, max: 0.9, transform: Transform.Linear), // subSampleRatio
+                new MinMaxParameterSpec(min: numberOfFeatures * 0.5, max: numberOfFeatures, transform: Transform.Linear), // featuresPrSplit
+            };
+
+            // Further split the training data to have a validation set to measure
+            // how well the model generalizes to unseen data during the optimization.
+            var validationSplit = new RandomTrainingTestIndexSplitter<double>(trainingPercentage: 0.7, seed: 24)
+                .SplitSet(trainSet.Observations, trainSet.Targets);
+
+            var treesPrIteration = 5;
+            var random = new Random(343);
+            // Define optimizer objective (function to minimize)
+            HyperbandObjectiveFunction minimize = (p, r) =>
+            {
+                //return new OptimizerResult(p, random.NextDouble());
+                // create the candidate learner using the current optimization parameters.
+                var candidateLearner = new RegressionSquareLossGradientBoostLearner(
+                        iterations: (int)(treesPrIteration * r),
+                        learningRate: p[0],
+                        maximumTreeDepth: (int)p[1],
+                        subSampleRatio: p[2],
+                        featuresPrSplit: (int)p[3],
+                        runParallel: false);
+
+                var candidateModel = candidateLearner.Learn(validationSplit.TrainingSet.Observations,
+                    validationSplit.TrainingSet.Targets);
+                var validationPredictions = candidateModel.Predict(validationSplit.TestSet.Observations);
+                var candidateError = metric.Error(validationSplit.TestSet.Targets, validationPredictions);
+
+                return new OptimizerResult(p, candidateError);
+            };
+
+            // create random search optimizer
+            var maximunIterationsPrConfiguration = 40;
+            var optimizer = new HyperbandOptimizer(parameters, maximunIterationsPrConfiguration, eta: 3);
+
+            var timer = new Stopwatch();
+
+            timer.Start();
+            // find best hyperparameters
+            var result = optimizer.Optimize(minimize);
+            timer.Stop();
+
+            var best = result.OrderBy(r => r.Error).First();
+
+            Trace.WriteLine($"Best Error: {best.Error} | Parameters: {string.Join(", ", best.ParameterSet)}");
+            Trace.WriteLine($"Total configuration count: {result.Count()}");
+            Trace.WriteLine($"Total time (ms): {timer.ElapsedMilliseconds}");
+
+            // create the final learner using the best hyperparameters.
+            var b = best.ParameterSet;
+            var learner = new RegressionSquareLossGradientBoostLearner(
+                        iterations: (int)(treesPrIteration * maximunIterationsPrConfiguration),
+                        learningRate: b[0],
+                        maximumTreeDepth: (int)b[1],
+                        subSampleRatio: b[2],
+                        featuresPrSplit: (int)b[3],
+                        runParallel: false);
+
+            // learn model with found parameters
+            var model = learner.Learn(trainSet.Observations, trainSet.Targets);
+
+            // predict the training and test set.
+            var trainPredictions = model.Predict(trainSet.Observations);
+            var testPredictions = model.Predict(testSet.Observations);
+
+            // measure the error on training and test set.
+            var trainError = metric.Error(trainSet.Targets, trainPredictions);
+            var testError = metric.Error(testSet.Targets, testPredictions);
+
+            // Optimizer found hyperparameters.
+            Trace.WriteLine(string.Format($"Test Error: {testError:0.00000}."));
+
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -23,9 +23,12 @@ namespace SharpLearning.Optimization.Test
                 return new OptimizerResult(p, error);
             };
         
-            var sut = new HyperbandOptimizer(parameters, 
-                maximunIterationsPrConfiguration: 81, 
-                eta: 5, skipLast: false);
+            var sut = new HyperbandOptimizer(
+                parameters, 
+                maximumUnitsOfCompute: 81, 
+                eta: 5, 
+                skipLastIterationOfEachRound: false,
+                seed: 34);
 
             var actual = sut.Optimize(minimize);
 

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -1,12 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SharpLearning.CrossValidation.TrainingTestSplitters;
-using SharpLearning.GradientBoost.Learners;
-using SharpLearning.InputOutput.Csv;
-using SharpLearning.Metrics.Regression;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -16,120 +9,101 @@ namespace SharpLearning.Optimization.Test
         [TestMethod]
         public void HyperbandOptimizer_Optimize()
         {
-            // Use StreamReader(filepath) when running from filesystem
-            var parser = new CsvParser(() => new StreamReader(@"E:\Git\open-source\SharpLearning.Examples\src\Resources\winequality-white.csv"));
-            var targetName = "quality";
-
-            // read feature matrix
-            var observations = parser.EnumerateRows(c => c != targetName)
-                .ToF64Matrix();
-
-            // read regression targets
-            var targets = parser.EnumerateRows(targetName)
-                .ToF64Vector();
-
-            // creates training test splitter, 
-            // Since this is a regression problem, we use the random training/test set splitter.
-            // 30 % of the data is used for the test set. 
-            var splitter = new RandomTrainingTestIndexSplitter<double>(trainingPercentage: 0.7, seed: 24);
-
-            var trainingTestSplit = splitter.SplitSet(observations, targets);
-            var trainSet = trainingTestSplit.TrainingSet;
-            var testSet = trainingTestSplit.TestSet;
-
-            // since this is a regression problem we are using square error as metric
-            // for evaluating how well the model performs.
-            var metric = new MeanSquaredErrorRegressionMetric();
-
-            // Usually better results can be achieved by tuning a gradient boost learner
-
-            var numberOfFeatures = trainSet.Observations.ColumnCount;
-
-            // Parameter ranges for the optimizer
-            // best parameter to tune on random forest is featuresPrSplit.
             var parameters = new IParameterSpec[]
             {
-                //new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear), // iterations
+                new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear), // iterations
                 new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10), // learning rate
                 new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear), // maximumTreeDepth
-                new MinMaxParameterSpec(min: 0.5, max: 0.9, transform: Transform.Linear), // subSampleRatio
-                new MinMaxParameterSpec(min: numberOfFeatures * 0.5, max: numberOfFeatures, transform: Transform.Linear), // featuresPrSplit
             };
 
-            // Further split the training data to have a validation set to measure
-            // how well the model generalizes to unseen data during the optimization.
-            var validationSplit = new RandomTrainingTestIndexSplitter<double>(trainingPercentage: 0.7, seed: 24)
-                .SplitSet(trainSet.Observations, trainSet.Targets);
-
-            var treesPrIteration = 5;
             var random = new Random(343);
-            // Define optimizer objective (function to minimize)
             HyperbandObjectiveFunction minimize = (p, r) =>
             {
-                //return new OptimizerResult(p, random.NextDouble());
-                // create the candidate learner using the current optimization parameters.
-                var candidateLearner = new RegressionSquareLossGradientBoostLearner(
-                        iterations: (int)(treesPrIteration * r),
-                        learningRate: p[0],
-                        maximumTreeDepth: (int)p[1],
-                        subSampleRatio: p[2],
-                        featuresPrSplit: (int)p[3],
-                        runParallel: false);
-
-                var candidateModel = candidateLearner.Learn(validationSplit.TrainingSet.Observations,
-                    validationSplit.TrainingSet.Targets);
-                var validationPredictions = candidateModel.Predict(validationSplit.TestSet.Observations);
-                var candidateError = metric.Error(validationSplit.TestSet.Targets, validationPredictions);
-
-                return new OptimizerResult(p, candidateError);
+                var error = random.NextDouble();
+                return new OptimizerResult(p, error);
             };
+        
+            var sut = new HyperbandOptimizer(parameters, 
+                maximunIterationsPrConfiguration: 81, 
+                eta: 5, skipLast: false);
 
-            // create random search optimizer
-            var maximunIterationsPrConfiguration = 81;
+            var actual = sut.Optimize(minimize);
 
-            var optimizer = new HyperbandOptimizer(parameters, 
-                maximunIterationsPrConfiguration, 
-                eta: 3, 
-                skipLast: true);
-
-            var timer = new Stopwatch();
-
-            timer.Start();
-            // find best hyperparameters
-            var result = optimizer.Optimize(minimize);
-            timer.Stop();
-
-            var best = result.OrderBy(r => r.Error).First();
-
-            Trace.WriteLine($"Best Error: {best.Error} | Parameters: {string.Join(", ", best.ParameterSet)}");
-            Trace.WriteLine($"Total configuration count: {result.Count()}");
-            Trace.WriteLine($"Total time (ms): {timer.ElapsedMilliseconds}");
-
-            // create the final learner using the best hyperparameters.
-            var b = best.ParameterSet;
-            var learner = new RegressionSquareLossGradientBoostLearner(
-                        iterations: (int)(treesPrIteration * maximunIterationsPrConfiguration),
-                        learningRate: b[0],
-                        maximumTreeDepth: (int)b[1],
-                        subSampleRatio: b[2],
-                        featuresPrSplit: (int)b[3],
-                        runParallel: false);
-
-            // learn model with found parameters
-            var model = learner.Learn(trainSet.Observations, trainSet.Targets);
-
-            // predict the training and test set.
-            var trainPredictions = model.Predict(trainSet.Observations);
-            var testPredictions = model.Predict(testSet.Observations);
-
-            // measure the error on training and test set.
-            var trainError = metric.Error(trainSet.Targets, trainPredictions);
-            var testError = metric.Error(testSet.Targets, testPredictions);
-
-            // Optimizer found hyperparameters.
-            Trace.WriteLine(string.Format($"Test Error: {testError:0.00000}."));
-
-            throw new NotImplementedException();
+            AssertOptimizerResults(Expected, actual);
         }
+
+        static void AssertOptimizerResults(OptimizerResult[] expected, OptimizerResult[] actual)
+        {
+            Assert.AreEqual(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                AssertOptimizerResult(expected[i], actual[i]);
+            }
+        }
+
+        static void AssertOptimizerResult(OptimizerResult expected, OptimizerResult actual)
+        {
+            const double delta = 0.000001;
+
+            Assert.AreEqual(expected.Error, actual.Error, delta);
+
+            var expectedParameterSet = expected.ParameterSet;
+            var actualParameterSet = actual.ParameterSet;
+
+            Assert.AreEqual(expectedParameterSet.Length, actualParameterSet.Length);
+
+            for (int i = 0; i < expectedParameterSet.Length; i++)
+            {
+                Assert.AreEqual(expectedParameterSet[i], actualParameterSet[i], delta);
+            }
+        }
+
+        static OptimizerResult[] Expected => new OptimizerResult[]
+        {
+            new OptimizerResult(new [] { 183.050454, 0.103778, 10.521202 }, 0.815090),
+            new OptimizerResult(new [] { 242.035154, 0.160589, 14.928944 }, 0.319450),
+            new OptimizerResult(new [] { 217.110439, 0.121371, 9.134293 }, 0.287873),
+            new OptimizerResult(new [] { 205.828006, 0.026428, 13.831848 }, 0.213150),
+            new OptimizerResult(new [] { 81.318916, 0.028789, 13.468363 }, 0.833401),
+            new OptimizerResult(new [] { 183.050454, 0.103778, 10.521202 }, 0.138057),
+            new OptimizerResult(new [] { 280.115839, 0.043236, 14.109365 }, 0.315902),
+            new OptimizerResult(new [] { 199.842478, 0.023487, 12.218300 }, 0.858262),
+            new OptimizerResult(new [] { 89.288205, 0.029247, 12.503943 }, 0.960621),
+            new OptimizerResult(new [] { 238.527937, 0.023610, 14.521096 }, 0.998539),
+            new OptimizerResult(new [] { 103.184215, 0.048606, 11.929732 }, 0.391503),
+            new OptimizerResult(new [] { 217.110439, 0.121371, 9.134293 }, 0.125866),
+            new OptimizerResult(new [] { 80.598836, 0.039832, 8.388401 }, 0.962324),
+            new OptimizerResult(new [] { 89.359300, 0.042719, 10.902781 }, 0.655116),
+            new OptimizerResult(new [] { 183.050454, 0.103778, 10.521202 }, 0.045531),
+            new OptimizerResult(new [] { 242.035154, 0.160589, 14.928944 }, 0.241034),
+            new OptimizerResult(new [] { 205.828006, 0.026428, 13.831848 }, 0.072501),
+            new OptimizerResult(new [] { 137.807164, 0.080876, 9.133881 }, 0.917069),
+            new OptimizerResult(new [] { 122.739555, 0.071284, 9.159947 }, 0.428372),
+            new OptimizerResult(new [] { 265.007895, 0.065434, 9.655193 }, 0.252369),
+            new OptimizerResult(new [] { 242.616914, 0.051308, 14.785707 }, 0.990477),
+            new OptimizerResult(new [] { 245.944001, 0.173415, 11.243352 }, 0.755331),
+            new OptimizerResult(new [] { 87.069973, 0.049606, 9.162192 }, 0.412378),
+            new OptimizerResult(new [] { 121.689890, 0.109421, 14.372696 }, 0.519928),
+            new OptimizerResult(new [] { 211.466343, 0.060338, 10.341543 }, 0.589474),
+            new OptimizerResult(new [] { 138.097042, 0.028550, 8.527269 }, 0.305832),
+            new OptimizerResult(new [] { 81.318916, 0.028789, 13.468363 }, 0.065642),
+            new OptimizerResult(new [] { 258.473191, 0.043830, 8.081241 }, 0.769086),
+            new OptimizerResult(new [] { 110.790052, 0.063165, 9.287423 }, 0.520903),
+            new OptimizerResult(new [] { 259.348583, 0.072041, 9.899872 }, 0.459911),
+            new OptimizerResult(new [] { 187.514870, 0.124334, 11.735301 }, 0.918126),
+            new OptimizerResult(new [] { 80.806287, 0.028735, 9.547892 }, 0.824839),
+            new OptimizerResult(new [] { 212.130398, 0.142035, 8.342675 }, 0.713911),
+            new OptimizerResult(new [] { 212.130398, 0.142035, 8.342675 }, 0.082547),
+            new OptimizerResult(new [] { 80.806287, 0.028735, 9.547892, }, 0.135099),
+            new OptimizerResult(new [] { 119.813471, 0.074485, 13.382158 }, 0.154206),
+            new OptimizerResult(new [] { 202.034806, 0.137801, 9.508964 },0.627903),
+            new OptimizerResult(new [] { 102.696143, 0.099462, 8.557010 },0.410965),
+            new OptimizerResult(new [] { 118.759207, 0.038629, 9.560888 },0.587768),
+            new OptimizerResult(new [] { 96.998060, 0.039504, 11.428746 },0.225692),
+            new OptimizerResult(new [] { 117.955108, 0.082906, 12.319315 }, 0.801867),
+            new OptimizerResult(new [] { 246.662655, 0.027162, 14.963403 }, 0.088704),
+            new OptimizerResult(new [] { 156.214348, 0.167765, 12.516866 }, 0.365275),
+            new OptimizerResult(new [] { 278.337940, 0.098931, 13.177449 }, 0.009549),
+        };
     }
 }

--- a/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
+++ b/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
@@ -25,11 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SharpLearning.Containers\SharpLearning.Containers.csproj" />
-    <ProjectReference Include="..\SharpLearning.CrossValidation\SharpLearning.CrossValidation.csproj" />
-    <ProjectReference Include="..\SharpLearning.GradientBoost\SharpLearning.GradientBoost.csproj" />
-    <ProjectReference Include="..\SharpLearning.InputOutput\SharpLearning.InputOutput.csproj" />
-    <ProjectReference Include="..\SharpLearning.Metrics\SharpLearning.Metrics.csproj" />
     <ProjectReference Include="..\SharpLearning.Optimization\SharpLearning.Optimization.csproj" />
   </ItemGroup>
 

--- a/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
+++ b/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
+++ b/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
@@ -25,6 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SharpLearning.Containers\SharpLearning.Containers.csproj" />
+    <ProjectReference Include="..\SharpLearning.CrossValidation\SharpLearning.CrossValidation.csproj" />
+    <ProjectReference Include="..\SharpLearning.GradientBoost\SharpLearning.GradientBoost.csproj" />
+    <ProjectReference Include="..\SharpLearning.InputOutput\SharpLearning.InputOutput.csproj" />
+    <ProjectReference Include="..\SharpLearning.Metrics\SharpLearning.Metrics.csproj" />
     <ProjectReference Include="..\SharpLearning.Optimization\SharpLearning.Optimization.csproj" />
   </ItemGroup>
 

--- a/src/SharpLearning.Optimization/HyperbandOptimizer.cs
+++ b/src/SharpLearning.Optimization/HyperbandOptimizer.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using SharpLearning.Optimization.ParameterSamplers;
 
 namespace SharpLearning.Optimization
 {
-    public delegate OptimizerResult HyperbandObjectiveFunction(double[] parameterSet, double budgetFactor);
+    public delegate OptimizerResult HyperbandObjectiveFunction(double[] parameterSet, double unitsOfCompute);
 
     /// <summary>
     /// Hyperband optimizer based on:
@@ -23,89 +21,92 @@ namespace SharpLearning.Optimization
         readonly IParameterSpec[] m_parameters;
         readonly IParameterSampler m_sampler;
 
-        readonly int m_max_iter; // maximum number of iterations.
-        readonly int m_eta; // defines configuration downsampling rate (default = 3)
+        readonly int m_maximumUnitsOfCompute;
+        readonly int m_eta;
 
-        readonly int m_sMax;
-        readonly int m_b;
+        readonly int m_numberOfRounds;
+        readonly int m_totalUnitsOfComputePerRound;
 
-        readonly bool m_skipLast;
+        readonly bool m_skipLastIterationOfEachRound;
 
         /// <summary>
-        /// TODO: Find better names for arguments.
+        /// Hyperband optimizer based on: https://arxiv.org/pdf/1603.06560.pdf
+        /// 
+        /// Hyperband controls a budget of compute for each set of hyperparameters, 
+        /// Initially it will run each parameter set with very little compute budget to get a taste of how they perform. 
+        /// Then it takes the best performers and runs them on a larger budget. 
         /// </summary>
-        /// <param name="maximunIterationsPrConfiguration"></param>
-        /// <param name=""></param>
+        /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
+        /// <param name="maximumUnitsOfCompute">This indicates the maximum units of compute.
+        /// A unit of compute could be 5 epochs over a dataset for instance. Consequently, 
+        /// a unit of compute should be chosen to be the minimum amount of computation where different 
+        /// hyperparameter configurations start to separate (or where it is clear that some settings diverge)></param>
+        /// <param name="eta">Controls the proportion of configurations discarded in each round.
+        /// Together with maximumUnitsOfCompute, it dictates how many rounds are considered</param>
+        /// <param name="skipLastIterationOfEachRound">True to skip the last, 
+        /// most computationally expensive, iteration of each round. Default is false.</param>
         public HyperbandOptimizer(IParameterSpec[] parameters, 
-            int maximunIterationsPrConfiguration = 81, int eta = 3,
-            bool skipLast = false)
+            int maximumUnitsOfCompute = 81, int eta = 3,
+            bool skipLastIterationOfEachRound = false,
+            int seed = 34)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
-            m_sampler = new RandomUniform(seed: 34);
-            // TODO: Add parameter checks.
+            m_sampler = new RandomUniform(seed);
 
-            m_max_iter = maximunIterationsPrConfiguration;
+            // This is called R in the paper.
+            m_maximumUnitsOfCompute = maximumUnitsOfCompute;
             m_eta = eta;
 
-            m_sMax =  (int)(Math.Log(m_max_iter) / Math.Log(m_eta));
-            m_b = (m_sMax + 1) * m_max_iter;
+            // This is called `s max` in the paper.
+            m_numberOfRounds =  (int)(Math.Log(m_maximumUnitsOfCompute) / Math.Log(m_eta));
+            // This is called `B` in the paper.
+            m_totalUnitsOfComputePerRound = (m_numberOfRounds + 1) * m_maximumUnitsOfCompute;
 
-            m_skipLast = skipLast;
+            m_skipLastIterationOfEachRound = skipLastIterationOfEachRound;
         }
 
         public OptimizerResult[] Optimize(HyperbandObjectiveFunction functionToMinimize)
         {
-            // Initialize the search
             var allResults = new List<OptimizerResult>();
 
-            //for (int s = m_sMax + 1; s > 0; s--)
-            for (int s = m_sMax; s >= 0; s--)
+            for (int rounds = m_numberOfRounds; rounds >= 0; rounds--)
             {
-                // initial number of configurations
-                var n = (int)Math.Ceiling((m_b / m_max_iter) * (Math.Pow(m_eta, s) / (s + 1)));
+                // Initial configurations count.
+                var initialConfigurationCount = (int)Math.Ceiling((m_totalUnitsOfComputePerRound / m_maximumUnitsOfCompute) 
+                    * (Math.Pow(m_eta, rounds) / (rounds + 1)));
 
-                // initial number of iterations per config
-                var r = m_max_iter * Math.Pow(m_eta, -s);
+                // Initial unitsOfCompute per parameter set.
+                var initialUnitsOfCompute = m_maximumUnitsOfCompute * Math.Pow(m_eta, -rounds);
 
-                // n random configurations
-                var T = CreateParameterSets(m_parameters, n);
+                var parameterSets = CreateParameterSets(m_parameters, initialConfigurationCount);
                 var results = new ConcurrentBag<OptimizerResult>();
 
-                var rounds = m_skipLast ? s : (s + 1);
-                for (int i = 0; i < rounds; i++)
+                var iterations = m_skipLastIterationOfEachRound ? rounds : (rounds + 1);
+                for (int iteration = 0; iteration < iterations; iteration++)
                 {
-                    // Run each of the n configs for <iterations> 
-                    // and keep best (n_configs / eta) configurations
+                    // Run each of the parameter sets with unitsOfCompute
+                    // and keep the best (configurationCount / m_eta) configurations
 
-                    var n_configs = n * Math.Pow(m_eta, -i);
-                    var n_iterations = r * Math.Pow(m_eta, i);
+                    var configurationCount = initialConfigurationCount * Math.Pow(m_eta, -iteration);
+                    var unitsOfCompute = initialUnitsOfCompute * Math.Pow(m_eta, iteration);
 
-                    Trace.WriteLine($"{(int)Math.Round(n_configs)} configurations x {n_iterations:F1} iterations each");
-
-                    foreach (var t in T)
+                    //Trace.WriteLine($"{(int)Math.Round(configurationCount)} configurations x {unitsOfCompute:F1} unitsOfCompute each");
+                    foreach (var parameterSet in parameterSets)
                     {
-                        var result = functionToMinimize(t, n_iterations);
+                        var result = functionToMinimize(parameterSet, unitsOfCompute);
                         results.Add(result);
                     }
 
-                    //var rangePartitioner = Partitioner.Create(T, true);
-                    //var options = new ParallelOptions { MaxDegreeOfParallelism = 8 };
-
-                    //Parallel.ForEach(rangePartitioner, options, (t, loopState) =>
-                    //{
-                    //    var result = functionToMinimize(t, n_iterations);
-                    //    results.Add(result);
-                    //});
-
                     // Select a number of best configurations for the next loop
-                    T = results.OrderBy(v => v.Error)
-                        .Take((int)Math.Round(n_configs / m_eta))
+                    var configurationsToKeep = (int)Math.Round(configurationCount / m_eta);
+                    parameterSets = results.OrderBy(v => v.Error)
+                        .Take(configurationsToKeep)
                         .Select(v => v.ParameterSet)
                         .ToArray();
                 }
-                allResults.AddRange(results);
 
-                Trace.WriteLine($" Lowest loss so far: {allResults.OrderBy(v => v.Error).First().Error:F4}");
+                allResults.AddRange(results);
+                //Trace.WriteLine($" Lowest loss so far: {allResults.OrderBy(v => v.Error).First().Error:F4}");
             }
 
             return allResults.ToArray();

--- a/src/SharpLearning.Optimization/HyperbandOptimizer.cs
+++ b/src/SharpLearning.Optimization/HyperbandOptimizer.cs
@@ -11,10 +11,12 @@ namespace SharpLearning.Optimization
     /// <summary>
     /// Hyperband optimizer based on:
     /// https://arxiv.org/pdf/1603.06560.pdf
-    /// 
     /// Implementation based on:
     /// https://github.com/zygmuntz/hyperband
     /// 
+    /// Hyperband controls a budget of compute for each set of hyperparameters, 
+    /// Initially it will run each parameter set with very little compute budget to get a taste of how they perform. 
+    /// Then it takes the best performers and runs them on a larger budget. 
     /// </summary>
     public sealed class HyperbandOptimizer
     {
@@ -51,6 +53,8 @@ namespace SharpLearning.Optimization
             int seed = 34)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            if(maximumUnitsOfCompute < 1) throw new ArgumentException(nameof(maximumUnitsOfCompute) + " must be at larger than 0");
+            if (eta < 1) throw new ArgumentException(nameof(eta) + " must be at larger than 0");
             m_sampler = new RandomUniform(seed);
 
             // This is called R in the paper.
@@ -62,6 +66,9 @@ namespace SharpLearning.Optimization
             // This is called `B` in the paper.
             m_totalUnitsOfComputePerRound = (m_numberOfRounds + 1) * m_maximumUnitsOfCompute;
 
+            // Suggestion by fastml: http://fastml.com/tuning-hyperparams-fast-with-hyperband/
+            // "One could discard the last tier (1 x 81, 2 x 81, etc.) in each round, 
+            // including the last round. This drastically reduces time needed.             
             m_skipLastIterationOfEachRound = skipLastIterationOfEachRound;
         }
 

--- a/src/SharpLearning.Optimization/HyperbandOptimizer.cs
+++ b/src/SharpLearning.Optimization/HyperbandOptimizer.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using SharpLearning.Optimization.ParameterSamplers;
+
+namespace SharpLearning.Optimization
+{
+    public delegate OptimizerResult HyperbandObjectiveFunction(double[] parameterSet, double budgetFactor);
+
+    /// <summary>
+    /// Hyperband optimizer based on:
+    /// https://arxiv.org/pdf/1603.06560.pdf
+    /// 
+    /// Implementation based on:
+    /// https://github.com/zygmuntz/hyperband
+    /// 
+    /// </summary>
+    public sealed class HyperbandOptimizer
+    {
+        readonly IParameterSpec[] m_parameters;
+        readonly IParameterSampler m_sampler;
+
+        readonly int m_max_iter; // maximum number of iterations.
+        readonly int m_eta; // defines configuration downsampling rate (default = 3)
+
+        readonly int m_sMax;
+        readonly int m_b;
+
+        /// <summary>
+        /// TODO: Find better names for arguments.
+        /// </summary>
+        /// <param name="maximunIterationsPrConfiguration"></param>
+        /// <param name=""></param>
+        public HyperbandOptimizer(IParameterSpec[] parameters, int maximunIterationsPrConfiguration = 81, int eta = 3)
+        {
+            m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            m_sampler = new RandomUniform(seed: 34);
+            // TODO: Add parameter checks.
+
+            m_max_iter = maximunIterationsPrConfiguration;
+            m_eta = eta;
+
+            m_sMax =  (int)(Math.Log(m_max_iter) / Math.Log(m_eta));
+            m_b = (m_sMax + 1) * m_max_iter;
+        }
+
+        public OptimizerResult[] Optimize(HyperbandObjectiveFunction functionToMinimize)
+        {
+            // Initialize the search
+            var allResults = new List<OptimizerResult>();
+
+            //for (int s = m_sMax + 1; s > 0; s--)
+            for (int s = m_sMax; s >= 0; s--)
+            {
+                // initial number of configurations
+                var n = (int)Math.Ceiling((m_b / m_max_iter) * (Math.Pow(m_eta, s) / (s + 1)));
+
+                // initial number of iterations per config
+                var r = m_max_iter * Math.Pow(m_eta, -s);
+
+                // n random configurations
+                var T = CreateParameterSets(m_parameters, n);
+                var results = new ConcurrentBag<OptimizerResult>();
+                for (int i = 0; i < s + 1; i++)
+                {
+                    // Run each of the n configs for <iterations> 
+                    // and keep best (n_configs / eta) configurations
+
+                    var n_configs = n * Math.Pow(m_eta, -i);
+                    var n_iterations = r * Math.Pow(m_eta, i);
+
+                    Trace.WriteLine($"{(int)Math.Round(n_configs)} configurations x {n_iterations:F1} iterations each");
+
+                    var rangePartitioner = Partitioner.Create(T, true);
+                    var options = new ParallelOptions { MaxDegreeOfParallelism = 8 };
+
+                    Parallel.ForEach(rangePartitioner, options, (t, loopState) =>
+                    {
+                        var result = functionToMinimize(t, n_iterations);
+                        results.Add(result);
+                    });
+
+                    // Select a number of best configurations for the next loop
+                    T = results.OrderBy(v => v.Error)
+                        .Take((int)Math.Round(n_configs / m_eta))
+                        .Select(v => v.ParameterSet)
+                        .ToArray();
+                }
+                allResults.AddRange(results);
+
+                Trace.WriteLine($" Lowest loss so far: {allResults.OrderBy(v => v.Error).First().Error:F4}");
+            }
+
+            return allResults.ToArray();
+        }
+
+        double[][] CreateParameterSets(IParameterSpec[] parameters, 
+            int setCount)
+        {
+            var newSearchSpace = new double[setCount][];
+            for (int i = 0; i < newSearchSpace.Length; i++)
+            {
+                var newParameters = new double[parameters.Length];
+                var index = 0;
+                foreach (var param in parameters)
+                {
+                    newParameters[index] = param.SampleValue(m_sampler);
+                    index++;
+                }
+                newSearchSpace[i] = newParameters;
+            }
+
+            return newSearchSpace;
+        }
+    }
+}

--- a/src/SharpLearning.RandomForest.Test/SharpLearning.RandomForest.Test.csproj
+++ b/src/SharpLearning.RandomForest.Test/SharpLearning.RandomForest.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.XGBoost.Test/SharpLearning.XGBoost.Test.csproj
+++ b/src/SharpLearning.XGBoost.Test/SharpLearning.XGBoost.Test.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request adds the `HyperbandOptimizer` to `SharpLearning.Optimization`. The implementation is based on the original article [Hyperband](https://arxiv.org/pdf/1603.06560.pdf) and the implementation by [fastml](http://fastml.com/tuning-hyperparams-fast-with-hyperband/).

Compared to the other optimizers from SharpLearning, Hyperband includes an extra parameter in the objective function, `unitsOfCompute`. Hyperband uses the `unitsOfCompute` parameter to control a budget of compute for each set of hyperparameters. Initially it will run each parameter set with very little compute budget to get a taste of how they perform. Then it takes the best performers and runs them on a larger budget.

The `unitOfCompute` parameter is used in the objective function, and could for instance be used to control the size of the training set, the number of trees in gradient boost, or the number of epochs for neural nets. One unit of compute could for instance be defined as 1000 samples in the training set. The `maximumUnitsOfCompute` is provided as an argument to the `HyperbandOptimizer`, and the optimzer will define a schedule for evaluating the hyperparameters on a budget.

A small experiment comparing the results and runtime of the `HyperbandOptimizer` vs. the `RandomSearchOptimizer`, optimizing a neural net (using CNTK) on the CIFAR-10 dataset:

**System**
**CPU: i7-4770**
**GPU: GTX1070**

| Optimizer        | Time (hours)           | Validation accuracy (%)  |
| ------------- |:-------------:| -----:|
| `RandomSearchOptimizer(iterations=100)`|  45.34 |  88.47 |
| `HyperbandOptimizer(skipLastIterationOfEachRound=false)` |  10.46  |   87.93 |
| `HyperbandOptimizer(skipLastIterationOfEachRound=true)`|  6.56  | 87.93 |

As can be seen the RandomSearchOptimizer finds a slightly better parameter set. However, the two Hyperband runs uses significant less time to find a solution that is nearly as good. In this case, skipping the last iteration of each round results in finding the same parameter set as when including all iterations. This will not be the case for all problem types, but it does provide a nice speed up for large problems.

In the end, Hyperband finds a solution that is almost as good, and reduces the time required by a factor of 4-7.

A future extension to the hyperband optimizer could be to use bayesian optimization instead of random search to select the parameter sets. This combination has proven very useful in: [Robust and Efficient Hyperparameter Optimization at Scale](https://arxiv.org/pdf/1807.01774.pdf).