### PR TITLE
0.30.2: Add HyperbandOptimizer.OptimizeBest method

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.30.1.0</Version>
-    <AssemblyVersion>0.30.1.0</AssemblyVersion>
-    <FileVersion>0.30.1.0</FileVersion>
+	  <Version>0.30.2.0</Version>
+    <AssemblyVersion>0.30.2.0</AssemblyVersion>
+    <FileVersion>0.30.2.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -7,6 +7,36 @@ namespace SharpLearning.Optimization.Test
     public class HyperbandOptimizerTest
     {
         [TestMethod]
+        public void HyperbandOptimizer_OptimizeBest()
+        {
+            var parameters = new IParameterSpec[]
+            {
+                new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear), // iterations
+                new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10), // learning rate
+                new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear), // maximumTreeDepth
+            };
+
+            var random = new Random(343);
+            HyperbandObjectiveFunction minimize = (p, r) =>
+            {
+                var error = random.NextDouble();
+                return new OptimizerResult(p, error);
+            };
+
+            var sut = new HyperbandOptimizer(
+                parameters,
+                maximumUnitsOfCompute: 81,
+                eta: 5,
+                skipLastIterationOfEachRound: false,
+                seed: 34);
+
+            var actual = sut.OptimizeBest(minimize);
+            var expected = new OptimizerResult(new[] { 278.337940, 0.098931, 13.177449 }, 0.009549);
+
+            AssertOptimizerResult(expected, actual);
+        }
+
+        [TestMethod]
         public void HyperbandOptimizer_Optimize()
         {
             var parameters = new IParameterSpec[]

--- a/src/SharpLearning.Optimization/HyperbandOptimizer.cs
+++ b/src/SharpLearning.Optimization/HyperbandOptimizer.cs
@@ -72,6 +72,22 @@ namespace SharpLearning.Optimization
             m_skipLastIterationOfEachRound = skipLastIterationOfEachRound;
         }
 
+        /// <summary>
+        /// Optimization using Hyberband.
+        /// Returns the result which best minimizes the provided function.
+        /// </summary>
+        /// <param name="functionToMinimize"></param>
+        /// <returns></returns>
+        public OptimizerResult OptimizeBest(HyperbandObjectiveFunction functionToMinimize) =>
+            // Return the best model found.
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
+
+        /// <summary>
+        /// Optimization using Hyberband.
+        /// Returns all results, chronologically ordered.
+        /// </summary>
+        /// <param name="functionToMinimize"></param>
+        /// <returns></returns>
         public OptimizerResult[] Optimize(HyperbandObjectiveFunction functionToMinimize)
         {
             var allResults = new List<OptimizerResult>();


### PR DESCRIPTION
Add missing `OptimizeBest` method for the `HyperbandOptimizer`. This method returns the best result found by the optimizer