### PR TITLE
0.31.1.0: Add SmacOptimizer, update argument names on HyperbandOptimizer and BayesianOptimizer, clean up SharpLearning.Optimization.Test project

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.31.0.0</Version>
-    <AssemblyVersion>0.31.0.0</AssemblyVersion>
-    <FileVersion>0.31.0.0</FileVersion>
+	  <Version>0.31.1.0</Version>
+    <AssemblyVersion>0.31.1.0</AssemblyVersion>
+    <FileVersion>0.31.1.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.AdaBoost.Test/SharpLearning.AdaBoost.Test.csproj
+++ b/src/SharpLearning.AdaBoost.Test/SharpLearning.AdaBoost.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.Containers.Test/SharpLearning.Containers.Test.csproj
+++ b/src/SharpLearning.Containers.Test/SharpLearning.Containers.Test.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
+++ b/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.DecisionTrees.Test/SharpLearning.DecisionTrees.Test.csproj
+++ b/src/SharpLearning.DecisionTrees.Test/SharpLearning.DecisionTrees.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.Ensemble.Test/SharpLearning.Ensemble.Test.csproj
+++ b/src/SharpLearning.Ensemble.Test/SharpLearning.Ensemble.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.FeatureTransformations.Test/SharpLearning.FeatureTransformations.Test.csproj
+++ b/src/SharpLearning.FeatureTransformations.Test/SharpLearning.FeatureTransformations.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.GradientBoost.Test/SharpLearning.GradientBoost.Test.csproj
+++ b/src/SharpLearning.GradientBoost.Test/SharpLearning.GradientBoost.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.InputOutput.Test/SharpLearning.InputOutput.Test.csproj
+++ b/src/SharpLearning.InputOutput.Test/SharpLearning.InputOutput.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.Metrics.Test/SharpLearning.Metrics.Test.csproj
+++ b/src/SharpLearning.Metrics.Test/SharpLearning.Metrics.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
+++ b/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="3.17.0" />
     <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -7,8 +7,6 @@ namespace SharpLearning.Optimization.Test
     [TestClass]
     public class BayesianOptimizerTest
     {
-        readonly double m_delta = 0.000001;
-
         [TestMethod]
         public void BayesianOptimizer_OptimizeBest()
         {
@@ -19,14 +17,14 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
             var sut = new BayesianOptimizer(parameters, 100, 5, 1);
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
 
             Assert.AreEqual(actual.Error, -0.74765422244251278, 0.0001);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -5.0065683270835173, m_delta);
-            Assert.AreEqual(actual.ParameterSet[1], -9.67008227467075, m_delta);
-            Assert.AreEqual(actual.ParameterSet[2], -0.24173704452893574, m_delta);
+            Assert.AreEqual(-5.0065683270835173, actual.ParameterSet[0], ObjectiveUtilities.Delta);
+            Assert.AreEqual(-9.67008227467075, actual.ParameterSet[1], ObjectiveUtilities.Delta);
+            Assert.AreEqual(-0.24173704452893574, actual.ParameterSet[2], ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -37,7 +35,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
             var sut = new BayesianOptimizer(parameters, 120, 5, 1);
-            var results = sut.Optimize(Minimize2);
+            var results = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]
@@ -46,31 +44,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 24.204380402436 },   7601.008090362)
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, m_delta);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), m_delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), 
+                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, m_delta);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), m_delta);
-        }
-
-        OptimizerResult Minimize(double[] x)
-        {
-            return new OptimizerResult(x, Math.Sin(x[0]) * Math.Cos(x[1]) * (1.0 / (Math.Abs(x[2]) + 1)));
-        }
-
-        OptimizerResult Minimize2(double[] parameters)
-        {
-            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
-            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
-
-            var cost = 0.0;
-
-            for (int i = 0; i < heights.Length; i++)
-            {
-                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
-            }
-
-            return new OptimizerResult(parameters, cost);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), 
+                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -17,14 +17,14 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
             var sut = new BayesianOptimizer(parameters, 100, 5, 1);
-            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
+            var actual = sut.OptimizeBest(Minimize);
 
             Assert.AreEqual(actual.Error, -0.74765422244251278, 0.0001);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(-5.0065683270835173, actual.ParameterSet[0], ObjectiveUtilities.Delta);
-            Assert.AreEqual(-9.67008227467075, actual.ParameterSet[1], ObjectiveUtilities.Delta);
-            Assert.AreEqual(-0.24173704452893574, actual.ParameterSet[2], ObjectiveUtilities.Delta);
+            Assert.AreEqual(-5.0065683270835173, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(-9.67008227467075, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.24173704452893574, actual.ParameterSet[2], Delta);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
             var sut = new BayesianOptimizer(parameters, 120, 5, 1);
-            var results = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var results = sut.Optimize(MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]
@@ -44,13 +44,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 24.204380402436 },   7601.008090362)
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
             Assert.AreEqual(expected.First().ParameterSet.First(), 
-                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.First().ParameterSet.First(), Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), 
-                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.Last().ParameterSet.First(), Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
@@ -26,14 +26,14 @@ namespace SharpLearning.Optimization.Test
                     maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
 
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
 
-            Assert.AreEqual(actual.Error, -0.99999949547279676, 0.0000001);
+            Assert.AreEqual(actual.Error, -0.99999949547279676, ObjectiveUtilities.Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, ObjectiveUtilities.Delta);
+            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, ObjectiveUtilities.Delta);
+            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace SharpLearning.Optimization.Test
                     maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
 
-            var results = sut.Optimize(Minimize2);
+            var results = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]
@@ -62,31 +62,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 37.7131485180996 }, 109.34381396350526)
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), 
+                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
-        }
-
-        OptimizerResult Minimize(double[] x)
-        {
-            return  new OptimizerResult(x, Math.Sin(x[0]) * Math.Cos(x[1]) * (1.0 / (Math.Abs(x[2]) + 1)));
-        }
-
-        OptimizerResult Minimize2(double[] parameters)
-        {
-            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
-            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
-
-            var cost = 0.0;
-
-            for (int i = 0; i < heights.Length; i++)
-            {
-                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
-            }
-
-            return new OptimizerResult(parameters, cost);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), 
+                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -26,14 +26,14 @@ namespace SharpLearning.Optimization.Test
                     maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
 
-            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
+            var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(actual.Error, -0.99999949547279676, ObjectiveUtilities.Delta);
+            Assert.AreEqual(actual.Error, -0.99999949547279676, Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, ObjectiveUtilities.Delta);
-            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, ObjectiveUtilities.Delta);
-            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, ObjectiveUtilities.Delta);
+            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, Delta);
+            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, Delta);
+            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, Delta);
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace SharpLearning.Optimization.Test
                     maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
 
-            var results = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var results = sut.Optimize(MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]
@@ -62,13 +62,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 37.7131485180996 }, 109.34381396350526)
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
             Assert.AreEqual(expected.First().ParameterSet.First(), 
-                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.First().ParameterSet.First(), Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), 
-                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.Last().ParameterSet.First(), Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -23,9 +24,9 @@ namespace SharpLearning.Optimization.Test
                 new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
                 new GridSearchOptimizer(parameters);
 
-            var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
 
-            Assert.AreEqual(111.20889999999987, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(111.20889999999987, actual.Error, Delta);
             CollectionAssert.AreEqual(new double[] { 37.5 }, actual.ParameterSet);
         }
 
@@ -45,7 +46,7 @@ namespace SharpLearning.Optimization.Test
                 new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
                 new GridSearchOptimizer(parameters);
 
-            var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var actual = sut.Optimize(MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[] 
             { 
@@ -53,13 +54,13 @@ namespace SharpLearning.Optimization.Test
               new OptimizerResult(new double[] { 10 }, 31638.9579) 
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
             Assert.AreEqual(expected.First().ParameterSet.First(), 
-                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.First().ParameterSet.First(), Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), 
-                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(),
+                actual.Last().ParameterSet.First(), Delta);
         }
 
         [TestMethod]

--- a/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
@@ -23,9 +23,9 @@ namespace SharpLearning.Optimization.Test
                 new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
                 new GridSearchOptimizer(parameters);
 
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
 
-            Assert.AreEqual(111.20889999999987, actual.Error, 0.00001);
+            Assert.AreEqual(111.20889999999987, actual.Error, ObjectiveUtilities.Delta);
             CollectionAssert.AreEqual(new double[] { 37.5 }, actual.ParameterSet);
         }
 
@@ -45,7 +45,7 @@ namespace SharpLearning.Optimization.Test
                 new GridSearchOptimizer(parameters, true, maxDegreeOfParallelism.Value) : 
                 new GridSearchOptimizer(parameters);
 
-            var actual = sut.Optimize(Minimize);
+            var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[] 
             { 
@@ -53,11 +53,13 @@ namespace SharpLearning.Optimization.Test
               new OptimizerResult(new double[] { 10 }, 31638.9579) 
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), 
+                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), 
+                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -65,21 +67,6 @@ namespace SharpLearning.Optimization.Test
         public void GridSearchOptimizer_ArgumentCheck_ParameterRanges()
         {
             var sut = new GridSearchOptimizer(null, false);
-        }
-
-        OptimizerResult Minimize(double[] parameters)
-        {
-            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
-            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
-
-            var cost = 0.0;
-
-            for (int i = 0; i < heights.Length; i++)
-            {
-                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
-            }
-
-            return new OptimizerResult(parameters, cost);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -11,9 +11,9 @@ namespace SharpLearning.Optimization.Test
         {
             var parameters = new IParameterSpec[]
             {
-                new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear), // iterations
-                new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10), // learning rate
-                new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear), // maximumTreeDepth
+                new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear),
+                new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10),
+                new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear),
             };
 
             var random = new Random(343);
@@ -41,9 +41,9 @@ namespace SharpLearning.Optimization.Test
         {
             var parameters = new IParameterSpec[]
             {
-                new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear), // iterations
-                new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10), // learning rate
-                new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear), // maximumTreeDepth
+                new MinMaxParameterSpec(min: 80, max: 300, transform: Transform.Linear),
+                new MinMaxParameterSpec(min: 0.02, max:  0.2, transform: Transform.Log10),
+                new MinMaxParameterSpec(min: 8, max: 15, transform: Transform.Linear),
             };
 
             var random = new Random(343);

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -25,7 +25,7 @@ namespace SharpLearning.Optimization.Test
 
             var sut = new HyperbandOptimizer(
                 parameters,
-                maximumUnitsOfCompute: 81,
+                maximumBudget: 81,
                 eta: 5,
                 skipLastIterationOfEachRound: false,
                 seed: 34);
@@ -55,7 +55,7 @@ namespace SharpLearning.Optimization.Test
         
             var sut = new HyperbandOptimizer(
                 parameters, 
-                maximumUnitsOfCompute: 81, 
+                maximumBudget: 81, 
                 eta: 5, 
                 skipLastIterationOfEachRound: false,
                 seed: 34);

--- a/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/HyperbandOptimizerTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -76,9 +77,7 @@ namespace SharpLearning.Optimization.Test
 
         static void AssertOptimizerResult(OptimizerResult expected, OptimizerResult actual)
         {
-            const double delta = 0.000001;
-
-            Assert.AreEqual(expected.Error, actual.Error, delta);
+            Assert.AreEqual(expected.Error, actual.Error, Delta);
 
             var expectedParameterSet = expected.ParameterSet;
             var actualParameterSet = actual.ParameterSet;
@@ -87,7 +86,7 @@ namespace SharpLearning.Optimization.Test
 
             for (int i = 0; i < expectedParameterSet.Length; i++)
             {
-                Assert.AreEqual(expectedParameterSet[i], actualParameterSet[i], delta);
+                Assert.AreEqual(expectedParameterSet[i], actualParameterSet[i], Delta);
             }
         }
 

--- a/src/SharpLearning.Optimization.Test/ObjectiveUtilities.cs
+++ b/src/SharpLearning.Optimization.Test/ObjectiveUtilities.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace SharpLearning.Optimization.Test
+{
+    public static class ObjectiveUtilities
+    {
+        public const double Delta = 0.000001;
+
+        public static OptimizerResult Minimize(double[] x)
+        {
+            return new OptimizerResult(x, Math.Sin(x[0]) * Math.Cos(x[1]) * (1.0 / (Math.Abs(x[2]) + 1)));
+        }
+
+        public static OptimizerResult MinimizeWeightFromHeight(double[] parameters)
+        {
+            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
+            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
+
+            var cost = 0.0;
+
+            for (int i = 0; i < heights.Length; i++)
+            {
+                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
+            }
+
+            return new OptimizerResult(parameters, cost);
+        }
+    }
+}

--- a/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -25,14 +25,14 @@ namespace SharpLearning.Optimization.Test
                 new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new ParticleSwarmOptimizer(parameters, 100);
 
-            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
+            var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(-0.64324321766401094, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(-0.64324321766401094, actual.Error, Delta);
             Assert.AreEqual(3, actual.ParameterSet.Length);
 
-            Assert.AreEqual(-4.92494268653156, actual.ParameterSet[0], ObjectiveUtilities.Delta);
-            Assert.AreEqual(10, actual.ParameterSet[1], ObjectiveUtilities.Delta);
-            Assert.AreEqual(-0.27508308116943514, actual.ParameterSet[2], ObjectiveUtilities.Delta);
+            Assert.AreEqual(-4.92494268653156, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(10, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.27508308116943514, actual.ParameterSet[2], Delta);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace SharpLearning.Optimization.Test
                 new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new ParticleSwarmOptimizer(parameters, 100);
 
-            var results = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var results = sut.Optimize(MinimizeWeightFromHeight);
 
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
@@ -61,13 +61,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 37.2514904205637 }, 118.093289672808),
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
             Assert.AreEqual(expected.First().ParameterSet.First(), 
-                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.First().ParameterSet.First(), Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), 
-                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.Last().ParameterSet.First(), Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
@@ -25,14 +25,14 @@ namespace SharpLearning.Optimization.Test
                 new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new ParticleSwarmOptimizer(parameters, 100);
 
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
 
-            Assert.AreEqual(actual.Error, -0.64324321766401094, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet.Length, 3);
+            Assert.AreEqual(-0.64324321766401094, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(3, actual.ParameterSet.Length);
 
-            Assert.AreEqual(actual.ParameterSet[0], -4.92494268653156, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[1], 10, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[2], -0.27508308116943514, 0.0000001);
+            Assert.AreEqual(-4.92494268653156, actual.ParameterSet[0], ObjectiveUtilities.Delta);
+            Assert.AreEqual(10, actual.ParameterSet[1], ObjectiveUtilities.Delta);
+            Assert.AreEqual(-0.27508308116943514, actual.ParameterSet[2], ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace SharpLearning.Optimization.Test
                 new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
                 new ParticleSwarmOptimizer(parameters, 100);
 
-            var results = sut.Optimize(Minimize2);
+            var results = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
 
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
@@ -61,31 +61,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 37.2514904205637 }, 118.093289672808),
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), 
+                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
-        }
-
-        OptimizerResult Minimize(double[] x)
-        {
-            return new OptimizerResult(x, Math.Sin(x[0]) * Math.Cos(x[1]) * (1.0 / (Math.Abs(x[2]) + 1)));
-        }
-
-        OptimizerResult Minimize2(double[] parameters)
-        {
-            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
-            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
-
-            var cost = 0.0;
-
-            for (int i = 0; i < heights.Length; i++)
-            {
-                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
-            }
-
-            return new OptimizerResult(parameters, cost);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), 
+                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -23,10 +24,10 @@ namespace SharpLearning.Optimization.Test
                 new RandomSearchOptimizer(parameters, 100, 42, true, maxDegreeOfParallelism.Value) : 
                 new RandomSearchOptimizer(parameters, 100);
 
-            var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
 
-            Assert.AreEqual(110.67173923600831, actual.Error, ObjectiveUtilities.Delta);
-            Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), ObjectiveUtilities.Delta);
+            Assert.AreEqual(110.67173923600831, actual.Error, Delta);
+            Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), Delta);
         }
 
         [TestMethod]
@@ -45,7 +46,7 @@ namespace SharpLearning.Optimization.Test
                 new RandomSearchOptimizer(parameters, 2, 42, true, maxDegreeOfParallelism.Value) : 
                 new RandomSearchOptimizer(parameters, 2);
 
-            var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var actual = sut.Optimize(MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[]
             {
@@ -53,13 +54,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 28.3729278125674 },  3690.81119818742),
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
             Assert.AreEqual(expected.First().ParameterSet.First(), 
-                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.First().ParameterSet.First(), Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), 
-                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
+                actual.Last().ParameterSet.First(), Delta);
         }
 
         [TestMethod]

--- a/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
@@ -23,10 +23,10 @@ namespace SharpLearning.Optimization.Test
                 new RandomSearchOptimizer(parameters, 100, 42, true, maxDegreeOfParallelism.Value) : 
                 new RandomSearchOptimizer(parameters, 100);
 
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
 
-            Assert.AreEqual(110.67173923600831, actual.Error, 0.00001);
-            Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), 0.00001);
+            Assert.AreEqual(110.67173923600831, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -45,7 +45,7 @@ namespace SharpLearning.Optimization.Test
                 new RandomSearchOptimizer(parameters, 2, 42, true, maxDegreeOfParallelism.Value) : 
                 new RandomSearchOptimizer(parameters, 2);
 
-            var actual = sut.Optimize(Minimize);
+            var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[]
             {
@@ -53,11 +53,13 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 28.3729278125674 },  3690.81119818742),
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), 
+                actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), 
+                actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -65,21 +67,6 @@ namespace SharpLearning.Optimization.Test
         public void RandomSearchOptimizer_ArgumentCheck_ParameterRanges()
         {
             var sut = new RandomSearchOptimizer(null, 10);
-        }
-
-        OptimizerResult Minimize(double[] parameters)
-        {
-            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
-            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
-
-            var cost = 0.0;
-
-            for (int i = 0; i < heights.Length; i++)
-            {
-                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
-            }
-
-            return new OptimizerResult(parameters, cost);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
+++ b/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -23,7 +23,8 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), 0.00001);
         }
 
-        public void SmacOptimizer_OptimizeBest2(int? maxDegreeOfParallelism)
+        [TestMethod]
+        public void SmacOptimizer_OptimizeBest2()
         {
             var parameters = new MinMaxParameterSpec[]
             {
@@ -33,7 +34,7 @@ namespace SharpLearning.Optimization.Test
             };
 
             var sut = new SmacOptimizer(parameters);
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(Minimize2);
 
             Assert.AreEqual(actual.Error, -0.99999949547279676, 0.0000001);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
@@ -73,6 +74,11 @@ namespace SharpLearning.Optimization.Test
         public void RandomSearchOptimizer_ArgumentCheck_ParameterRanges()
         {
             var sut = new RandomSearchOptimizer(null, 10);
+        }
+
+        OptimizerResult Minimize2(double[] x)
+        {
+            return new OptimizerResult(x, Math.Sin(x[0]) * Math.Cos(x[1]) * (1.0 / (Math.Abs(x[2]) + 1)));
         }
 
         OptimizerResult Minimize(double[] parameters)

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -22,6 +22,7 @@ namespace SharpLearning.Optimization.Test
                 functionEvaluationsPerIterationCount: 1,
                 localSearchPointCount: 10,
                 randomSearchPointCount: 1000,
+                epsilon: 0.00001,
                 seed: 42);
 
             var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
@@ -46,6 +47,7 @@ namespace SharpLearning.Optimization.Test
                 functionEvaluationsPerIterationCount: 1,
                 localSearchPointCount: 10,
                 randomSearchPointCount: 1000,
+                epsilon: 0.00001,
                 seed: 42);
 
             var actual = sut.OptimizeBest(Minimize);
@@ -72,6 +74,7 @@ namespace SharpLearning.Optimization.Test
                 functionEvaluationsPerIterationCount: 1,
                 localSearchPointCount: 10,
                 randomSearchPointCount: 1000,
+                epsilon: 0.00001,
                 seed: 42);
 
             var actual = sut.Optimize(MinimizeWeightFromHeight);
@@ -171,6 +174,7 @@ namespace SharpLearning.Optimization.Test
                 functionEvaluationsPerIterationCount: functionEvaluationsPerIterationCount,
                 localSearchPointCount: 10,
                 randomSearchPointCount: 1000,
+                epsilon: 0.00001,
                 seed: 42);
 
             // Using SmacOptimizer in an open loop.

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
 namespace SharpLearning.Optimization.Test
 {
@@ -22,10 +24,10 @@ namespace SharpLearning.Optimization.Test
                 randomSearchPointCount: 1000,
                 seed: 42);
 
-            var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
 
-            Assert.AreEqual(109.616853578648, actual.Error, ObjectiveUtilities.Delta);
-            Assert.AreEqual(37.6315924979893, actual.ParameterSet.Single(), ObjectiveUtilities.Delta);
+            Assert.AreEqual(109.616853578648, actual.Error, Delta);
+            Assert.AreEqual(37.6315924979893, actual.ParameterSet.Single(), Delta);
         }
 
         [TestMethod]
@@ -46,14 +48,14 @@ namespace SharpLearning.Optimization.Test
                 randomSearchPointCount: 1000,
                 seed: 42);
 
-            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
+            var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(-0.964878416222769, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(-0.964878416222769, actual.Error, Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(-7.8487638560350819, actual.ParameterSet[0], ObjectiveUtilities.Delta);
-            Assert.AreEqual(6.2840940040927826, actual.ParameterSet[1], ObjectiveUtilities.Delta);
-            Assert.AreEqual(0.036385473812179825, actual.ParameterSet[2], ObjectiveUtilities.Delta);
+            Assert.AreEqual(-7.8487638560350819, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(6.2840940040927826, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(0.036385473812179825, actual.ParameterSet[2], Delta);
         }
 
         [TestMethod]
@@ -72,7 +74,7 @@ namespace SharpLearning.Optimization.Test
                 randomSearchPointCount: 1000,
                 seed: 42);
 
-            var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
+            var actual = sut.Optimize(MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[]
             {
@@ -80,11 +82,63 @@ namespace SharpLearning.Optimization.Test
                 new OptimizerResult(new double[] { 41.8333740634068 },  806.274612132759),
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), Delta);
+        }
+
+        [TestMethod]
+        public void SmacOptimizer_OptimizeBest_MultipleParameters_Open_Loop()
+        {
+            var results = new List<OptimizerResult>();
+
+            OptimizerResult actual = RunOpenLoopOptimizationTest(results);
+
+            Assert.AreEqual(-0.964878416222769, actual.Error, Delta);
+            Assert.AreEqual(actual.ParameterSet.Length, 3);
+
+            Assert.AreEqual(-7.8487638560350819, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(6.2840940040927826, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(0.036385473812179825, actual.ParameterSet[2], Delta);
+        }
+
+        OptimizerResult RunOpenLoopOptimizationTest(List<OptimizerResult> results)
+        {
+            var parameters = new MinMaxParameterSpec[]
+            {
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+            };
+
+            var iterations = 80;
+            var randomStartingPointsCount = 20;
+            var functionEvaluationsPerIterationCount = 1;
+
+            var sut = new SmacOptimizer(parameters,
+                iterations: iterations,
+                randomStartingPointCount: randomStartingPointsCount,
+                functionEvaluationsPerIterationCount: functionEvaluationsPerIterationCount,
+                localSearchPointCount: 10,
+                randomSearchPointCount: 1000,
+                seed: 42);
+
+            var initialParameterSets = sut.ProposeParameterSets(randomStartingPointsCount, results);
+
+            var initializationResults = sut.RunParameterSets(Minimize, initialParameterSets);
+            results.AddRange(initializationResults);
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var parameterSets = sut.ProposeParameterSets(functionEvaluationsPerIterationCount, results);
+                var iterationResults = sut.RunParameterSets(Minimize, parameterSets);
+                results.AddRange(iterationResults);
+            }
+
+            var actual = results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First(); ;
+            return actual;
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SharpLearning.Optimization.Test
@@ -8,23 +7,23 @@ namespace SharpLearning.Optimization.Test
     public class SmacOptimizerTest
     {
         [TestMethod]
-        public void SmacOptimizer_OptimizeBest()
+        public void SmacOptimizer_OptimizeBest_SingleParameter()
         {
             var parameters = new MinMaxParameterSpec[]
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = new SmacOptimizer(parameters);
+            var sut = new SmacOptimizer(parameters, 80);
 
-            var actual = sut.OptimizeBest(Minimize);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
 
-            Assert.AreEqual(110.67173923600831, actual.Error, 0.00001);
-            Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), 0.00001);
+            Assert.AreEqual(109.42115405881532, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(37.669741473006894, actual.ParameterSet.Single(), ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
-        public void SmacOptimizer_OptimizeBest2()
+        public void SmacOptimizer_OptimizeBest_MultipleParameters()
         {
             var parameters = new MinMaxParameterSpec[]
             {
@@ -33,15 +32,15 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
 
-            var sut = new SmacOptimizer(parameters);
-            var actual = sut.OptimizeBest(Minimize2);
+            var sut = new SmacOptimizer(parameters, 80);
+            var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
 
-            Assert.AreEqual(actual.Error, -0.99999949547279676, 0.0000001);
+            Assert.AreEqual(actual.Error, -0.98652950641642445, ObjectiveUtilities.Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, 0.0000001);
-            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[0], -7.8353112367146238, ObjectiveUtilities.Delta);
+            Assert.AreEqual(actual.ParameterSet[1], 6.2707440537729973, ObjectiveUtilities.Delta);
+            Assert.AreEqual(actual.ParameterSet[2], 0.01339932438609992, ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -49,51 +48,24 @@ namespace SharpLearning.Optimization.Test
         {
             var parameters = new MinMaxParameterSpec[]
             {
-                new MinMaxParameterSpec(10.0, 37.5, Transform.Linear)
+                new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = new RandomSearchOptimizer(parameters, 100);
+            var sut = new SmacOptimizer(parameters, 80);
 
-            var actual = sut.Optimize(Minimize);
+            var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 13.8749507052707 }, 23438.2157641635),
-                new OptimizerResult(new double[] { 28.3729278125674 },  3690.81119818742),
+                new OptimizerResult(new double[] { 90.513222660177 }, 114559.431919558),
+                new OptimizerResult(new double[] { 37.6697414730069 },  109.421154058815),
             };
 
-            Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
-            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), 0.0001);
+            Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), ObjectiveUtilities.Delta);
 
-            Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
-            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void RandomSearchOptimizer_ArgumentCheck_ParameterRanges()
-        {
-            var sut = new RandomSearchOptimizer(null, 10);
-        }
-
-        OptimizerResult Minimize2(double[] x)
-        {
-            return new OptimizerResult(x, Math.Sin(x[0]) * Math.Cos(x[1]) * (1.0 / (Math.Abs(x[2]) + 1)));
-        }
-
-        OptimizerResult Minimize(double[] parameters)
-        {
-            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
-            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
-
-            var cost = 0.0;
-
-            for (int i = 0; i < heights.Length; i++)
-            {
-                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
-            }
-
-            return new OptimizerResult(parameters, cost);
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), ObjectiveUtilities.Delta);
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
@@ -92,9 +93,9 @@ namespace SharpLearning.Optimization.Test
         [TestMethod]
         public void SmacOptimizer_OptimizeBest_MultipleParameters_Open_Loop()
         {
-            var results = new List<OptimizerResult>();
+            var emptyResults = new List<OptimizerResult>();
 
-            OptimizerResult actual = RunOpenLoopOptimizationTest(results);
+            OptimizerResult actual = RunOpenLoopOptimizationTest(emptyResults);
 
             Assert.AreEqual(-0.964878416222769, actual.Error, Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
@@ -102,6 +103,65 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(-7.8487638560350819, actual.ParameterSet[0], Delta);
             Assert.AreEqual(6.2840940040927826, actual.ParameterSet[1], Delta);
             Assert.AreEqual(0.036385473812179825, actual.ParameterSet[2], Delta);
+        }
+
+        [TestMethod]
+        public void SmacOptimizer_OptimizeBest_MultipleParameters_Open_Loop_Using_PreviousResults()
+        {
+            var previousResults = new List<OptimizerResult>()
+            {
+                new OptimizerResult(new[] {-6.83357586936726,6.0834837966056,-0.0766206300242906}, -0.476143174040315),
+                new OptimizerResult(new[] {-7.29391428515963,6.0834837966056,1.01057317620636}, -0.41300737879641),
+                new OptimizerResult(new[] {-7.29391428515963,6.0834837966056,1.01057317620636}, -0.41300737879641),
+                new OptimizerResult(new[] {-8.05557010604794,-5.14662256238359,0.0363854738121798}, -0.397724266113204),
+                new OptimizerResult(new[] {-8.06241082868651,5.88012208038947,-1.5210571566229}, -0.356975377788698),
+                new OptimizerResult(new[] {4.42408777513732,0.472018332440413,1.7076749781648}, -0.315360461074171),
+                new OptimizerResult(new[] {-8.14483470197061,7.54724840519356,0.0363854738121798}, -0.279108605472165),
+                new OptimizerResult(new[] {-6.64746686660101,6.7109944004151,-0.214493549528761}, -0.266917186594653),
+                new OptimizerResult(new[] {5.34224593795009,-6.45170816986435,-2.1147669628797}, -0.255769932489526),
+                new OptimizerResult(new[] {-7.84876385603508,6.28409400409278,3.1447921661403}, -0.241263236969342),
+                new OptimizerResult(new[] {-7.84876385603508,4.96554990995934,-0.0766206300242906}, -0.232637166385485),
+                new OptimizerResult(new[] {-8.14041409554911,7.16927772256047,1.75166608381628}, -0.220476103560048),
+                new OptimizerResult(new[] {-7.84876385603508,6.0834837966056,-3.60210045874217}, -0.212970686239402),
+                new OptimizerResult(new[] {-7.29391428515963,5.22505613752876,1.01057317620636}, -0.206689239504653),
+                new OptimizerResult(new[] {-9.20479206331297,6.0834837966056,-0.0766206300242906}, -0.198657722521128),
+                new OptimizerResult(new[] {-8.25145286426481,5.27274844947865,-1.82163462593296}, -0.17367847378187),
+                new OptimizerResult(new[] {-7.84876385603508,6.0834837966056,5.3824106023565}, -0.153564625328103),
+                new OptimizerResult(new[] {-1.37364300497511,-1.35665034472786,-0.585322245296707}, -0.131453543138338),
+                new OptimizerResult(new[] {-7.84876385603508,7.74187722138216,-0.0766206300242906}, -0.103906821017427),
+                new OptimizerResult(new[] {9.20868899636375,-9.38389458664874,1.51842798642741}, -0.0850657757130275),
+                new OptimizerResult(new[] {-7.72406242681856,5.70825177044992,9.95585092341334}, -0.0759553721161318),
+                new OptimizerResult(new[] {1.65093947744506,-4.37866264692445,-4.29402069854272}, -0.0616761163702651),
+                new OptimizerResult(new[] {-9.37414173938993,6.28409400409278,0.0363854738121798}, -0.0488375857853505),
+                new OptimizerResult(new[] {3.38691201684387,5.42095644186295,-5.71318443664964}, -0.0235423806080941),
+                new OptimizerResult(new[] {-6.48224856540665,-7.13935053774125,7.05507751417117}, -0.0160884883078408),
+                new OptimizerResult(new[] {-9.68539061941457,7.96346846873102,-0.990608674935348}, -0.0141441279734299),
+                new OptimizerResult(new[] {-9.41382774124566,5.12580713030221,0.630654976996897}, -0.00269773409680873),
+                new OptimizerResult(new[] {6.7694738305963,1.56629731485913,-2.12145430600338}, 0.000673595210828553),
+                new OptimizerResult(new[] {-0.0282478006688169,2.87566112022645,-4.84997700660023}, 0.00465834522866944),
+                new OptimizerResult(new[] {3.50054986472267,8.01269467827524,7.36471213277649}, 0.00663762309484885),
+                new OptimizerResult(new[] {3.05129390817662,-6.16640157819092,7.49125691013935}, 0.0105475373675896),
+            };
+
+            OptimizerResult actual = RunOpenLoopOptimizationTest(previousResults);
+
+            Assert.AreEqual(-0.96958858653084612, actual.Error, Delta);
+            Assert.AreEqual(actual.ParameterSet.Length, 3);
+
+            Assert.AreEqual(-1.5411651281365977, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(6.3397464232238683, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.029263948104000903, actual.ParameterSet[2], Delta);
+        }
+
+        static void Trace(IEnumerable<OptimizerResult> results)
+        {
+            var b = new StringBuilder();
+            foreach (var result in results)
+            {
+                b.AppendLine("new OptimizerResult(new[] {" + $"{string.Join(",", result.ParameterSet)}" + "}," + $" {result.Error}),");
+            }
+
+            System.Diagnostics.Trace.Write(b.ToString());
         }
 
         OptimizerResult RunOpenLoopOptimizationTest(List<OptimizerResult> results)
@@ -125,8 +185,8 @@ namespace SharpLearning.Optimization.Test
                 randomSearchPointCount: 1000,
                 seed: 42);
 
+            // Using SmacOptimizer in an open loop.
             var initialParameterSets = sut.ProposeParameterSets(randomStartingPointsCount, results);
-
             var initializationResults = sut.RunParameterSets(Minimize, initialParameterSets);
             results.AddRange(initializationResults);
 
@@ -137,8 +197,9 @@ namespace SharpLearning.Optimization.Test
                 results.AddRange(iterationResults);
             }
 
-            var actual = results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First(); ;
-            return actual;
+            Trace(results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error));
+
+            return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static SharpLearning.Optimization.Test.ObjectiveUtilities;
@@ -153,6 +154,53 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(-1.5411651281365977, actual.ParameterSet[0], Delta);
             Assert.AreEqual(6.3397464232238683, actual.ParameterSet[1], Delta);
             Assert.AreEqual(-0.029263948104000903, actual.ParameterSet[2], Delta);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SmacOptimizer_ArgumentCheck_ParameterRanges()
+        {
+            var sut = new SmacOptimizer(null, 20);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void SmacOptimizer_ArgumentCheck_Iterations()
+        {
+            var sut = new SmacOptimizer(new[] { new GridParameterSpec(0, 1, 2) }, 
+                0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void SmacOptimizer_ArgumentCheck_RandomStartingPointCount()
+        {
+            var sut = new SmacOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void SmacOptimizer_ArgumentCheck_FunctionEvaluationsPerIterationCount()
+        {
+            var sut = new SmacOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 20, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void SmacOptimizer_ArgumentCheck_LocalSearchPointCount()
+        {
+            var sut = new SmacOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 20, 30, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void SmacOptimizer_ArgumentCheck_RandomSearchPointCount()
+        {
+            var sut = new SmacOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 20, 30, 40, 0);
         }
 
         OptimizerResult RunOpenLoopOptimizationTest(List<OptimizerResult> results)

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -153,17 +153,6 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(-0.029263948104000903, actual.ParameterSet[2], Delta);
         }
 
-        static void Trace(IEnumerable<OptimizerResult> results)
-        {
-            var b = new StringBuilder();
-            foreach (var result in results)
-            {
-                b.AppendLine("new OptimizerResult(new[] {" + $"{string.Join(",", result.ParameterSet)}" + "}," + $" {result.Error}),");
-            }
-
-            System.Diagnostics.Trace.Write(b.ToString());
-        }
-
         OptimizerResult RunOpenLoopOptimizationTest(List<OptimizerResult> results)
         {
             var parameters = new MinMaxParameterSpec[]
@@ -196,8 +185,6 @@ namespace SharpLearning.Optimization.Test
                 var iterationResults = sut.RunParameterSets(Minimize, parameterSets);
                 results.AddRange(iterationResults);
             }
-
-            Trace(results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error));
 
             return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
         }

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SharpLearning.Optimization.Test
+{
+    [TestClass]
+    public class SmacOptimizerTest
+    {
+        [TestMethod]
+        public void SmacOptimizer_OptimizeBest()
+        {
+            var parameters = new MinMaxParameterSpec[]
+            {
+                new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
+            };
+
+            var sut = new SmacOptimizer(parameters);
+
+            var actual = sut.OptimizeBest(Minimize);
+
+            Assert.AreEqual(110.67173923600831, actual.Error, 0.00001);
+            Assert.AreEqual(37.533294194160632, actual.ParameterSet.Single(), 0.00001);
+        }
+
+        public void SmacOptimizer_OptimizeBest2(int? maxDegreeOfParallelism)
+        {
+            var parameters = new MinMaxParameterSpec[]
+            {
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+            };
+
+            var sut = new SmacOptimizer(parameters);
+            var actual = sut.OptimizeBest(Minimize);
+
+            Assert.AreEqual(actual.Error, -0.99999949547279676, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet.Length, 3);
+
+            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, 0.0000001);
+            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, 0.0000001);
+        }
+
+        [TestMethod]
+        public void SmacOptimizer_Optimize()
+        {
+            var parameters = new MinMaxParameterSpec[]
+            {
+                new MinMaxParameterSpec(10.0, 37.5, Transform.Linear)
+            };
+
+            var sut = new RandomSearchOptimizer(parameters, 100);
+
+            var actual = sut.Optimize(Minimize);
+
+            var expected = new OptimizerResult[]
+            {
+                new OptimizerResult(new double[] { 13.8749507052707 }, 23438.2157641635),
+                new OptimizerResult(new double[] { 28.3729278125674 },  3690.81119818742),
+            };
+
+            Assert.AreEqual(expected.First().Error, actual.First().Error, 0.0001);
+            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), 0.0001);
+
+            Assert.AreEqual(expected.Last().Error, actual.Last().Error, 0.0001);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), 0.0001);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void RandomSearchOptimizer_ArgumentCheck_ParameterRanges()
+        {
+            var sut = new RandomSearchOptimizer(null, 10);
+        }
+
+        OptimizerResult Minimize(double[] parameters)
+        {
+            var heights = new double[] { 1.47, 1.50, 1.52, 1.55, 1.57, 1.60, 1.63, 1.65, 1.68, 1.70, 1.73, 1.75, 1.78, 1.80, 1.83 };
+            var weights = new double[] { 52.21, 53.12, 54.48, 55.84, 57.20, 58.57, 59.93, 61.29, 63.11, 64.47, 66.28, 68.10, 69.92, 72.19, 74.46 };
+
+            var cost = 0.0;
+
+            for (int i = 0; i < heights.Length; i++)
+            {
+                cost += (parameters[0] * heights[i] - weights[i]) * (parameters[0] * heights[i] - weights[i]);
+            }
+
+            return new OptimizerResult(parameters, cost);
+        }
+    }
+}

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -14,7 +14,13 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = new SmacOptimizer(parameters, 80);
+            var sut = new SmacOptimizer(parameters,
+                iterations: 80,
+                randomStartingPointCount: 20,
+                functionEvaluationsPerIterationCount: 1,
+                localSearchPointCount: 10,
+                randomSearchPointCount: 1000,
+                seed: 42);
 
             var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
 
@@ -32,7 +38,14 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
 
-            var sut = new SmacOptimizer(parameters, 80);
+            var sut = new SmacOptimizer(parameters,
+                iterations: 80,
+                randomStartingPointCount: 20,
+                functionEvaluationsPerIterationCount: 1,
+                localSearchPointCount: 10,
+                randomSearchPointCount: 1000,
+                seed: 42);
+
             var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
 
             Assert.AreEqual(-0.964878416222769, actual.Error, ObjectiveUtilities.Delta);
@@ -51,7 +64,13 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = new SmacOptimizer(parameters, 80);
+            var sut = new SmacOptimizer(parameters,
+                iterations: 80,
+                randomStartingPointCount: 20,
+                functionEvaluationsPerIterationCount: 1,
+                localSearchPointCount: 10,
+                randomSearchPointCount: 1000,
+                seed: 42);
 
             var actual = sut.Optimize(ObjectiveUtilities.MinimizeWeightFromHeight);
 

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -18,8 +18,8 @@ namespace SharpLearning.Optimization.Test
 
             var actual = sut.OptimizeBest(ObjectiveUtilities.MinimizeWeightFromHeight);
 
-            Assert.AreEqual(109.42115405881532, actual.Error, ObjectiveUtilities.Delta);
-            Assert.AreEqual(37.669741473006894, actual.ParameterSet.Single(), ObjectiveUtilities.Delta);
+            Assert.AreEqual(109.616853578648, actual.Error, ObjectiveUtilities.Delta);
+            Assert.AreEqual(37.6315924979893, actual.ParameterSet.Single(), ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -35,12 +35,12 @@ namespace SharpLearning.Optimization.Test
             var sut = new SmacOptimizer(parameters, 80);
             var actual = sut.OptimizeBest(ObjectiveUtilities.Minimize);
 
-            Assert.AreEqual(actual.Error, -0.98652950641642445, ObjectiveUtilities.Delta);
+            Assert.AreEqual(-0.964878416222769, actual.Error, ObjectiveUtilities.Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -7.8353112367146238, ObjectiveUtilities.Delta);
-            Assert.AreEqual(actual.ParameterSet[1], 6.2707440537729973, ObjectiveUtilities.Delta);
-            Assert.AreEqual(actual.ParameterSet[2], 0.01339932438609992, ObjectiveUtilities.Delta);
+            Assert.AreEqual(-7.8487638560350819, actual.ParameterSet[0], ObjectiveUtilities.Delta);
+            Assert.AreEqual(6.2840940040927826, actual.ParameterSet[1], ObjectiveUtilities.Delta);
+            Assert.AreEqual(0.036385473812179825, actual.ParameterSet[2], ObjectiveUtilities.Delta);
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace SharpLearning.Optimization.Test
             var expected = new OptimizerResult[]
             {
                 new OptimizerResult(new double[] { 90.513222660177 }, 114559.431919558),
-                new OptimizerResult(new double[] { 37.6697414730069 },  109.421154058815),
+                new OptimizerResult(new double[] { 41.8333740634068 },  806.274612132759),
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, ObjectiveUtilities.Delta);

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 

--- a/src/SharpLearning.Optimization/BayesianOptimizer.cs
+++ b/src/SharpLearning.Optimization/BayesianOptimizer.cs
@@ -216,7 +216,7 @@ namespace SharpLearning.Optimization
                 // initialize random starting points for the first iteration
                 for (int i = 0; i < m_numberOfStartingPoints; i++)
                 {
-                    var set = CreateParameterSet();
+                    var set = RandomSearchOptimizer.SampleParameterSet(m_parameters, m_sampler);
                     var score = functionToMinimize(set).Error;
                     iterations++;
 
@@ -261,7 +261,8 @@ namespace SharpLearning.Optimization
                     {
                         // if the beset parameter set is sampled again.
                         // Add a new random parameter set.
-                        parameterSet = CreateParameterSet();
+                        parameterSet = RandomSearchOptimizer
+                            .SampleParameterSet(m_parameters, m_sampler);
                     }
 
                     var result = functionToMinimize(parameterSet);
@@ -338,19 +339,6 @@ namespace SharpLearning.Optimization
             }
 
             return false;
-        }
-
-        double[] CreateParameterSet()
-        {
-            var newPoint = new double[m_parameters.Length];
-
-            for (int i = 0; i < m_parameters.Length; i++)
-            {
-                var parameter = m_parameters[i];
-                newPoint[i] = parameter.SampleValue(m_sampler);
-            }
-
-            return newPoint;
         }
     }
 }

--- a/src/SharpLearning.Optimization/GridSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/GridSearchOptimizer.cs
@@ -72,7 +72,6 @@ namespace SharpLearning.Optimization
                 });
             }
 
-            // return all results ordered
             return results.ToArray();
         }
 

--- a/src/SharpLearning.Optimization/HyperbandOptimizer.cs
+++ b/src/SharpLearning.Optimization/HyperbandOptimizer.cs
@@ -6,7 +6,13 @@ using SharpLearning.Optimization.ParameterSamplers;
 
 namespace SharpLearning.Optimization
 {
-    public delegate OptimizerResult HyperbandObjectiveFunction(double[] parameterSet, double unitsOfCompute);
+    /// <summary>
+    /// Objective function for hyperband optimizer.
+    /// </summary>
+    /// <param name="parameterSet">Parameter set to run.</param>
+    /// <param name="budget">Budget under which to run the parameter set.</param>
+    /// <returns></returns>
+    public delegate OptimizerResult HyperbandObjectiveFunction(double[] parameterSet, double budget);
 
     /// <summary>
     /// Hyperband optimizer based on:
@@ -23,11 +29,11 @@ namespace SharpLearning.Optimization
         readonly IParameterSpec[] m_parameters;
         readonly IParameterSampler m_sampler;
 
-        readonly int m_maximumUnitsOfCompute;
+        readonly int m_maximumBudget;
         readonly int m_eta;
 
         readonly int m_numberOfRounds;
-        readonly int m_totalUnitsOfComputePerRound;
+        readonly int m_totalBudgetPerRound;
 
         readonly bool m_skipLastIterationOfEachRound;
 
@@ -39,32 +45,33 @@ namespace SharpLearning.Optimization
         /// Then it takes the best performers and runs them on a larger budget. 
         /// </summary>
         /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
-        /// <param name="maximumUnitsOfCompute">This indicates the maximum units of compute.
-        /// A unit of compute could be 5 epochs over a dataset for instance. Consequently, 
+        /// <param name="maximumBudget">This provides the maximum budget.
+        /// One unit of compute could be 5 epochs over a dataset for instance. Consequently, 
         /// a unit of compute should be chosen to be the minimum amount of computation where different 
         /// hyperparameter configurations start to separate (or where it is clear that some settings diverge)></param>
         /// <param name="eta">Controls the proportion of configurations discarded in each round.
         /// Together with maximumUnitsOfCompute, it dictates how many rounds are considered</param>
         /// <param name="skipLastIterationOfEachRound">True to skip the last, 
         /// most computationally expensive, iteration of each round. Default is false.</param>
+        /// <param name="seed"></param>
         public HyperbandOptimizer(IParameterSpec[] parameters, 
-            int maximumUnitsOfCompute = 81, int eta = 3,
+            int maximumBudget = 81, int eta = 3,
             bool skipLastIterationOfEachRound = false,
             int seed = 34)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
-            if(maximumUnitsOfCompute < 1) throw new ArgumentException(nameof(maximumUnitsOfCompute) + " must be at larger than 0");
+            if(maximumBudget < 1) throw new ArgumentException(nameof(maximumBudget) + " must be at larger than 0");
             if (eta < 1) throw new ArgumentException(nameof(eta) + " must be at larger than 0");
             m_sampler = new RandomUniform(seed);
 
             // This is called R in the paper.
-            m_maximumUnitsOfCompute = maximumUnitsOfCompute;
+            m_maximumBudget = maximumBudget;
             m_eta = eta;
 
             // This is called `s max` in the paper.
-            m_numberOfRounds =  (int)(Math.Log(m_maximumUnitsOfCompute) / Math.Log(m_eta));
+            m_numberOfRounds =  (int)(Math.Log(m_maximumBudget) / Math.Log(m_eta));
             // This is called `B` in the paper.
-            m_totalUnitsOfComputePerRound = (m_numberOfRounds + 1) * m_maximumUnitsOfCompute;
+            m_totalBudgetPerRound = (m_numberOfRounds + 1) * m_maximumBudget;
 
             // Suggestion by fastml: http://fastml.com/tuning-hyperparams-fast-with-hyperband/
             // "One could discard the last tier (1 x 81, 2 x 81, etc.) in each round, 
@@ -95,11 +102,11 @@ namespace SharpLearning.Optimization
             for (int rounds = m_numberOfRounds; rounds >= 0; rounds--)
             {
                 // Initial configurations count.
-                var initialConfigurationCount = (int)Math.Ceiling((m_totalUnitsOfComputePerRound / m_maximumUnitsOfCompute) 
+                var initialConfigurationCount = (int)Math.Ceiling((m_totalBudgetPerRound / m_maximumBudget) 
                     * (Math.Pow(m_eta, rounds) / (rounds + 1)));
 
-                // Initial unitsOfCompute per parameter set.
-                var initialUnitsOfCompute = m_maximumUnitsOfCompute * Math.Pow(m_eta, -rounds);
+                // Initial budget per parameter set.
+                var initialBudget = m_maximumBudget * Math.Pow(m_eta, -rounds);
 
                 var parameterSets = RandomSearchOptimizer.SampleRandomParameterSets(initialConfigurationCount,
                     m_parameters, m_sampler);
@@ -109,16 +116,16 @@ namespace SharpLearning.Optimization
                 var iterations = m_skipLastIterationOfEachRound ? rounds : (rounds + 1);
                 for (int iteration = 0; iteration < iterations; iteration++)
                 {
-                    // Run each of the parameter sets with unitsOfCompute
+                    // Run each of the parameter sets with budget
                     // and keep the best (configurationCount / m_eta) configurations
 
                     var configurationCount = initialConfigurationCount * Math.Pow(m_eta, -iteration);
-                    var unitsOfCompute = initialUnitsOfCompute * Math.Pow(m_eta, iteration);
+                    var budget = initialBudget * Math.Pow(m_eta, iteration);
 
-                    //Trace.WriteLine($"{(int)Math.Round(configurationCount)} configurations x {unitsOfCompute:F1} unitsOfCompute each");
+                    //Trace.WriteLine($"{(int)Math.Round(configurationCount)} configurations x {budget:F1} budget each");
                     foreach (var parameterSet in parameterSets)
                     {
-                        var result = functionToMinimize(parameterSet, unitsOfCompute);
+                        var result = functionToMinimize(parameterSet, budget);
                         results.Add(result);
                     }
 

--- a/src/SharpLearning.Optimization/HyperbandOptimizer.cs
+++ b/src/SharpLearning.Optimization/HyperbandOptimizer.cs
@@ -101,7 +101,9 @@ namespace SharpLearning.Optimization
                 // Initial unitsOfCompute per parameter set.
                 var initialUnitsOfCompute = m_maximumUnitsOfCompute * Math.Pow(m_eta, -rounds);
 
-                var parameterSets = CreateParameterSets(m_parameters, initialConfigurationCount);
+                var parameterSets = RandomSearchOptimizer.SampleRandomParameterSets(initialConfigurationCount,
+                    m_parameters, m_sampler);
+
                 var results = new ConcurrentBag<OptimizerResult>();
 
                 var iterations = m_skipLastIterationOfEachRound ? rounds : (rounds + 1);
@@ -133,25 +135,6 @@ namespace SharpLearning.Optimization
             }
 
             return allResults.ToArray();
-        }
-
-        double[][] CreateParameterSets(IParameterSpec[] parameters, 
-            int setCount)
-        {
-            var newSearchSpace = new double[setCount][];
-            for (int i = 0; i < newSearchSpace.Length; i++)
-            {
-                var newParameters = new double[parameters.Length];
-                var index = 0;
-                foreach (var param in parameters)
-                {
-                    newParameters[index] = param.SampleValue(m_sampler);
-                    index++;
-                }
-                newSearchSpace[i] = newParameters;
-            }
-
-            return newSearchSpace;
         }
     }
 }

--- a/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
+++ b/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
@@ -71,6 +71,7 @@ namespace SharpLearning.Optimization
 
         /// <summary>
         /// Optimization using swarm optimization. Returns results for all particles.
+        /// </summary>
         /// <param name="functionToMinimize"></param>
         /// <returns></returns>
         public OptimizerResult[] Optimize(Func<double[], OptimizerResult> functionToMinimize)

--- a/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
+++ b/src/SharpLearning.Optimization/ParticleSwarmOptimizer.cs
@@ -112,7 +112,7 @@ namespace SharpLearning.Optimization
             // random initialize particles
             for (int i = 0; i < m_numberOfParticles; i++)
             {
-                particles[i] = CreateParticle();
+                particles[i] = RandomSearchOptimizer.SampleParameterSet(m_parameters, m_sampler);
             }
 
             // iterate for find best
@@ -167,19 +167,6 @@ namespace SharpLearning.Optimization
             {
                 newValues[i] = Math.Max(minValues[i], Math.Min(newValues[i], maxValues[i]));
             }
-        }
-
-        double[] CreateParticle()
-        {
-            var newPoint = new double[m_parameters.Length];
-
-            for (int i = 0; i < m_parameters.Length; i++)
-            {
-                var parameter = m_parameters[i];
-                newPoint[i] = parameter.SampleValue(m_sampler);
-            }
-
-            return newPoint;
         }
     }
 }

--- a/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
@@ -56,7 +56,8 @@ namespace SharpLearning.Optimization
         public OptimizerResult[] Optimize(Func<double[], OptimizerResult> functionToMinimize)
         {
             // Generate the cartesian product between all parameters
-            var parameterSets = CreateParameterSets(m_parameters);
+            var parameterSets = SampleRandomParameterSets(m_iterations, 
+                m_parameters, m_sampler);
 
             // Initialize the search
             var results = new ConcurrentBag<OptimizerResult>();
@@ -86,23 +87,43 @@ namespace SharpLearning.Optimization
             return results.ToArray();
         }
 
-
-        double[][] CreateParameterSets(IParameterSpec[] parameters)
+        /// <summary>
+        /// Samples a set of random parameter sets.
+        /// </summary>
+        /// <param name="parameterSetCount"></param>
+        /// <param name="parameters"></param>
+        /// <param name="sampler"></param>
+        /// <returns></returns>
+        public static double[][] SampleRandomParameterSets(int parameterSetCount, 
+            IParameterSpec[] parameters, IParameterSampler sampler)
         {
-            var newSearchSpace = new double[m_iterations][];
-            for (int i = 0; i < newSearchSpace.Length; i++)
-			{
-                var newParameters = new double[parameters.Length];
-                var index = 0;
-                foreach (var param in parameters)
-                {
-                    newParameters[index] = param.SampleValue(m_sampler);
-                    index++;
-                }
-                newSearchSpace[i] = newParameters;
-			}
+            var parameterSets = new double[parameterSetCount][];
+            for (int i = 0; i < parameterSetCount; i++)
+            {
+                parameterSets[i] = SampleParameterSet(parameters, sampler);
+            }
 
-            return newSearchSpace;
+            return parameterSets;
+        }
+
+        /// <summary>
+        /// Samples a random parameter set.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <param name="sampler"></param>
+        /// <returns></returns>
+        public static double[] SampleParameterSet(IParameterSpec[] parameters, 
+            IParameterSampler sampler)
+        {
+            var parameterSet = new double[parameters.Length];
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+                parameterSet[i] = parameter.SampleValue(sampler);
+            }
+
+            return parameterSet;
         }
     }
 }

--- a/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
@@ -82,8 +82,6 @@ namespace SharpLearning.Optimization
                 });
             }
 
-
-            // return all results ordered
             return results.ToArray();
         }
 

--- a/src/SharpLearning.Optimization/SharpLearning.Optimization.csproj
+++ b/src/SharpLearning.Optimization/SharpLearning.Optimization.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SharpLearning.Common.Interfaces\SharpLearning.Common.Interfaces.csproj" />
     <ProjectReference Include="..\SharpLearning.Containers\SharpLearning.Containers.csproj" />
     <ProjectReference Include="..\SharpLearning.RandomForest\SharpLearning.RandomForest.csproj" />

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -110,7 +110,6 @@ namespace SharpLearning.Optimization
                 results.AddRange(iterationResults);
             }
 
-            // return all results ordered
             return results.ToArray();
         }
 

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -24,6 +24,7 @@ namespace SharpLearning.Optimization
         readonly int m_functionEvaluationsPerIterationCount;
         readonly int m_localSearchPointCount;
         readonly int m_randomSearchPointCount;
+        readonly double m_epsilon;
 
         // Important to use extra trees learner to have split between features calculated as: 
         // m_random.NextDouble() * (max - min) + min; 
@@ -47,6 +48,7 @@ namespace SharpLearning.Optimization
         /// to use in the greedy local search (default is (10)</param>
         /// <param name="randomSearchPointCount">The number of random parameter sets
         /// used when maximizing the expected improvement acquisition function (default is 1000)</param>
+        /// <param name="epsilon">Threshold for ending local search (default is 0.00001)</param>
         /// <param name="seed"></param>
         public SmacOptimizer(IParameterSpec[] parameters,
             int iterations,
@@ -54,6 +56,7 @@ namespace SharpLearning.Optimization
             int functionEvaluationsPerIterationCount = 1,
             int localSearchPointCount = 10,
             int randomSearchPointCount = 1000,
+            double epsilon = 0.00001,
             int seed = 42)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
@@ -67,6 +70,7 @@ namespace SharpLearning.Optimization
             m_functionEvaluationsPerIterationCount = functionEvaluationsPerIterationCount;
             m_localSearchPointCount = localSearchPointCount;
             m_randomSearchPointCount = randomSearchPointCount;
+            m_epsilon = epsilon;
 
             // Hyper parameters for regression extra trees learner. 
             // These are based on the values suggested in http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf.
@@ -208,7 +212,7 @@ namespace SharpLearning.Optimization
             // Perform local search.
             foreach (var parameterSet in parentParameterSets)
             {
-                var bestParameterSet = LocalSearch(parentParameterSets, model, best, epsilon: 0.00001);
+                var bestParameterSet = LocalSearch(parentParameterSets, model, best, m_epsilon);
                 parameterSets.Add(bestParameterSet);
             }
 

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -29,7 +29,7 @@ namespace SharpLearning.Optimization
             int iterationCount = 10,
             int startParameterSetCount = 20, 
             int localSearchParentCount = 10,
-            int randomEISearchParameterSetsCount = 10000,
+            int randomEISearchParameterSetsCount = 1000,
             int seed = 42)
         {
             m_random = new Random(seed);
@@ -43,7 +43,7 @@ namespace SharpLearning.Optimization
 
             // Hyper parameters for regression extra trees learner. These are based on the values suggested in http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf.
             // However, according to the author Frank Hutter, the hyper parameters for the forest model should not matter that much.
-            m_learner = new RegressionExtremelyRandomizedTreesLearner(trees: 30,
+            m_learner = new RegressionExtremelyRandomizedTreesLearner(trees: 10,
                 minimumSplitSize: 2,
                 maximumTreeDepth: 2000,
                 featuresPrSplit: parameters.Length,

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -181,12 +181,8 @@ namespace SharpLearning.Optimization
 
         /// <summary>
         /// Performs a local one-mutation neighborhood greedy search.
+        /// Stop search when no neighbors increase expected improvement.
         /// </summary>
-        /// <param name="parentConfigurations">Starting parameter set configuration.</param>
-        /// <param name="model">Trained forest, for evaluation of points.</param>
-        /// <param name="bestScore">Best performance seen thus far.</param>
-        /// <param name="epsilon">Threshold for when to stop the local search.</param>
-        /// <returns></returns>
         (double[] configuration, double expectedImprovement) LocalSearch(double[][] parentConfigurations, 
             RegressionForestModel model, double bestScore, double epsilon)
         {

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -65,6 +65,17 @@ namespace SharpLearning.Optimization
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
 
+            if(iterations < 1) throw new ArgumentException(nameof(iterations) + 
+                "must be at least 1. Was: " + iterations);
+            if (randomStartingPointCount < 1) throw new ArgumentException(nameof(randomStartingPointCount) +
+                "must be at least 1. Was: " + randomStartingPointCount);
+            if (functionEvaluationsPerIterationCount < 1) throw new ArgumentException(nameof(functionEvaluationsPerIterationCount) +
+                "must be at least 1. Was: " + functionEvaluationsPerIterationCount);
+            if (localSearchPointCount < 1) throw new ArgumentException(nameof(localSearchPointCount) +
+                "must be at least 1. Was: " + localSearchPointCount);
+            if (randomSearchPointCount < 1) throw new ArgumentException(nameof(randomSearchPointCount) +
+                "must be at least 1. Was: " + randomSearchPointCount);
+
             m_random = new Random(seed);
             // Use member to seed the random uniform sampler.
             m_sampler = new RandomUniform(m_random.Next());

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -130,14 +130,14 @@ namespace SharpLearning.Optimization
         /// Propose a new list of parameter sets.
         /// </summary>
         /// <param name="parameterSetCount">The number of parameter sets to propose</param>
-        /// <param name="previousRuns">Results from previous runs.  
+        /// <param name="previousResults">Results from previous runs.  
         /// These are used in the model for proposing new parameter sets.
         /// If no results are provided, random parameter sets will be returned.</param>
         /// <returns></returns>
         public double[][] ProposeParameterSets(int parameterSetCount, 
-            IReadOnlyList<OptimizerResult> previousRuns = null)
+            IReadOnlyList<OptimizerResult> previousResults = null)
         {
-            var previousParameterSetCount = previousRuns == null ? 0 : previousRuns.Count;
+            var previousParameterSetCount = previousResults == null ? 0 : previousResults.Count;
             if (previousParameterSetCount < m_randomStartingPointsCount)
             {
                 var randomParameterSetCount = Math.Min(parameterSetCount,
@@ -149,7 +149,7 @@ namespace SharpLearning.Optimization
                 return randomParameterSets;
             }
 
-            var validParameterSets = previousRuns.Where(v => !double.IsNaN(v.Error));            
+            var validParameterSets = previousResults.Where(v => !double.IsNaN(v.Error));            
             var model = FitModel(validParameterSets);
 
             return GenerateCandidateParameterSets(parameterSetCount, validParameterSets.ToList(), model);
@@ -168,16 +168,16 @@ namespace SharpLearning.Optimization
         }
 
         double[][] GenerateCandidateParameterSets(int parameterSetCount, 
-            IReadOnlyList<OptimizerResult> previousRuns, RegressionForestModel model)
+            IReadOnlyList<OptimizerResult> previousResults, RegressionForestModel model)
         {
             // Get top parameter sets from previous runs.
-            var topParameterSets = previousRuns.OrderBy(v => v.Error)
+            var topParameterSets = previousResults.OrderBy(v => v.Error)
                 .Take(m_localSearchPointCount).Select(v => v.ParameterSet).ToArray();
 
             // Perform local search using the top parameter sets from previous run.
             var challengerCount = (int)Math.Ceiling(parameterSetCount / 2.0F);
             var challengers = GreedyPlusRandomSearch(topParameterSets, model,
-                challengerCount, previousRuns);
+                challengerCount, previousResults);
 
             // Create random parameter sets.
             var randomParameterSetCount = parameterSetCount - challengers.Length;
@@ -198,10 +198,10 @@ namespace SharpLearning.Optimization
         }
 
         double[][] GreedyPlusRandomSearch(double[][] parentParameterSets, RegressionForestModel model, 
-            int parameterSetCount, IReadOnlyList<OptimizerResult> previousRuns)
+            int parameterSetCount, IReadOnlyList<OptimizerResult> previousResults)
         {
             // TODO: Handle maximization and minimization. Currently minimizes.
-            var best = previousRuns.Min(v => v.Error);
+            var best = previousResults.Min(v => v.Error);
 
             var parameterSets = new List<(double[] parameterSet, double EI)>();
            

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -12,6 +12,8 @@ namespace SharpLearning.Optimization
     /// Implementation of the SMAC algorithm for hyperparameter optimization.
     /// Based on: Sequential Model-Based Optimization for General Algorithm Configuration:
     /// https://ml.informatik.uni-freiburg.de/papers/11-LION5-SMAC.pdf
+    /// And ML.Net implementation:
+    /// https://github.com/dotnet/machinelearning/blob/master/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
     /// Uses Bayesian optimization in tandem with a greedy local search on the top performing solutions.
     /// </summary>
     public class SmacOptimizer : IOptimizer
@@ -36,6 +38,8 @@ namespace SharpLearning.Optimization
         /// Based on: Sequential Model-Based Optimization for General Algorithm Configuration:
         /// https://ml.informatik.uni-freiburg.de/papers/11-LION5-SMAC.pdf
         /// Uses Bayesian optimization in tandem with a greedy local search on the top performing solutions.
+        /// And ML.Net implementation:
+        /// https://github.com/dotnet/machinelearning/blob/master/src/Microsoft.ML.Sweeper/Algorithms/SmacSweeper.cs
         /// </summary>
         /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
         /// <param name="iterations">The number of iterations to perform.
@@ -222,8 +226,8 @@ namespace SharpLearning.Optimization
                 var parameterSet = RandomSearchOptimizer
                     .SampleParameterSet(m_parameters, m_sampler);
 
-                var ei = ComputeExpectedImprovement(best, parameterSet, model);
-                parameterSets.Add((parameterSet, ei));
+                var expectedImprovement = ComputeExpectedImprovement(best, parameterSet, model);
+                parameterSets.Add((parameterSet, expectedImprovement));
             }
 
             // Take the best parameterSets. Here we want the max expected improvement.

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -277,6 +277,7 @@ namespace SharpLearning.Optimization
                 {
                     // Copy parent and mutate one parameter.
                     var newParameterSet = parentParameterSet.ToArray();
+                    // TODO: Original paper normalizes all numerical parameters between 0 and 1.
                     newParameterSet[i] = parameterSpec.SampleValue(m_sampler);
                     neighbors.Add(newParameterSet);
                 }

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -95,7 +95,8 @@ namespace SharpLearning.Optimization
                 var randomParameterSetCount = Math.Min(parameterSetCount,
                     m_startParameterSetCount - previousParameterSets);
 
-                var randomParameterSets = SampleRandomParameterSets(randomParameterSetCount);
+                var randomParameterSets = RandomSearchOptimizer.SampleRandomParameterSets(
+                    randomParameterSetCount, m_parameters, m_sampler);
 
                 return randomParameterSets;
             }
@@ -132,8 +133,9 @@ namespace SharpLearning.Optimization
                 (int)Math.Ceiling(parameterSetCount / 2.0F), previousRuns);
 
             // Create random parameter sets.
-            var randomParameterSets = parameterSetCount - challengers.Length;
-            var randomChallengers = SampleRandomParameterSets(randomParameterSets);
+            var randomParameterSetCount = parameterSetCount - challengers.Length;
+            var randomChallengers = RandomSearchOptimizer.SampleRandomParameterSets(
+                randomParameterSetCount, m_parameters, m_sampler);
 
             // Interleave challengers and random parameter sets.
             return InterLeaveModelBasedAndRandomParameterSets(challengers, randomChallengers);
@@ -166,7 +168,9 @@ namespace SharpLearning.Optimization
             // Additional set of random parameterSets to choose from during local search.
             for (int i = 0; i < m_randomEISearchParameterSetsCount; i++)
             {
-                var parameterSet = SampleParameterSet();
+                var parameterSet = RandomSearchOptimizer
+                    .SampleParameterSet(m_parameters, m_sampler);
+
                 var ei = ComputeExpectedImprovement(best, parameterSet, model);
                 parameterSets.Add((parameterSet, ei));
             }
@@ -240,30 +244,6 @@ namespace SharpLearning.Optimization
             var mean = prediction.Prediction;
             var variance = prediction.Variance;
             return AcquisitionFunctions.ExpectedImprovement(best, mean, variance);
-        }
-
-        double[][] SampleRandomParameterSets(int parameterSetCount)
-        {
-            var parameterSets = new double[parameterSetCount][];
-            for (int i = 0; i < parameterSetCount; i++)
-            {
-                parameterSets[i] = SampleParameterSet();
-            }
-
-            return parameterSets;
-        }
-
-        double[] SampleParameterSet()
-        {
-            var parameterSet = new double[m_parameters.Length];
-
-            for (int i = 0; i < m_parameters.Length; i++)
-            {
-                var parameter = m_parameters[i];
-                parameterSet[i] = parameter.SampleValue(m_sampler);
-            }
-
-            return parameterSet;
         }
 
         class ParameterSetEqualityComparer : IEqualityComparer<(double[], double)>

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -37,11 +37,12 @@ namespace SharpLearning.Optimization
         /// Uses Bayesian optimization in tandem with a greedy local search on the top performing solutions.
         /// </summary>
         /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
-        /// <param name="iterations">The number of iterations to perform</param>
+        /// <param name="iterations">The number of iterations to perform.
+        /// Iteration * functionEvaluationsPerIteration = totalFunctionEvaluations</param>
         /// <param name="randomStartingPointCount">Number of randomly parameter sets used 
         /// for initialization (default is 20)</param>
         /// <param name="functionEvaluationsPerIterationCount">The number of function evaluations per iteration. 
-        /// (default is 1).</param>
+        /// The parameter sets are included in order of most promising outcome (default is 1)</param>
         /// <param name="localSearchPointCount">The number of top contenders 
         /// to use in the greedy local search (default is (10)</param>
         /// <param name="randomSearchPointCount">The number of random parameter sets

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -92,30 +92,49 @@ namespace SharpLearning.Optimization
 
             // Initialize the search
             var results = new List<OptimizerResult>();
-            RunParameterSets(functionToMinimize, initialParameterSets, results);
+            var initializationResults = RunParameterSets(functionToMinimize, initialParameterSets);
+            results.AddRange(initializationResults);
 
             for (int iteration = 0; iteration < m_iterations; iteration++)
             {
                 var parameterSets = ProposeParameterSets(m_functionEvaluationsPerIterationCount, results);
-                RunParameterSets(functionToMinimize, parameterSets, results);
+                var iterationResults = RunParameterSets(functionToMinimize, parameterSets);
+                results.AddRange(iterationResults);
             }
 
             // return all results ordered
             return results.ToArray();
         }
 
-        void RunParameterSets(Func<double[], OptimizerResult> functionToMinimize, 
-            double[][] parameterSets, List<OptimizerResult> results)
+        /// <summary>
+        /// Runs a set of parameter sets and returns the results.
+        /// </summary>
+        /// <param name="functionToMinimize"></param>
+        /// <param name="parameterSets"></param>
+        /// <returns></returns>
+        public List<OptimizerResult> RunParameterSets(Func<double[], OptimizerResult> functionToMinimize, 
+            double[][] parameterSets)
         {
+            var results = new List<OptimizerResult>();
             foreach (var parameterSet in parameterSets)
             {
                 // Get the current parameters for the current point
                 var result = functionToMinimize(parameterSet);
                 results.Add(result);
             }
+
+            return results;
         }
 
-        double[][] ProposeParameterSets(int parameterSetCount, 
+        /// <summary>
+        /// Propose a new list of parameter sets.
+        /// </summary>
+        /// <param name="parameterSetCount">The number of parameter sets to propose</param>
+        /// <param name="previousRuns">Results from previous runs.  
+        /// These are used in the model for proposing new parameter sets.
+        /// If no results are provided, random parameter sets will be returned.</param>
+        /// <returns></returns>
+        public double[][] ProposeParameterSets(int parameterSetCount, 
             IReadOnlyList<OptimizerResult> previousRuns = null)
         {
             var previousParameterSetCount = previousRuns == null ? 0 : previousRuns.Count;

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -94,11 +94,7 @@ namespace SharpLearning.Optimization
                 var randomParameterSetCount = Math.Min(parameterSetCount,
                     m_startParameterSetCount - previousParameterSets);
 
-                var randomParameterSets = new double[randomParameterSetCount][];
-                for (int i = 0; i < randomParameterSetCount; i++)
-                {
-                    randomParameterSets[i] = CreateParameterSet();
-                }
+                var randomParameterSets = SampleRandomParameterSets(randomParameterSetCount);
 
                 return randomParameterSets;
             }
@@ -136,11 +132,7 @@ namespace SharpLearning.Optimization
 
             // Create random parameter sets.
             var randomParameterSets = parameterSetCount - challengers.Length;
-            var randomChallengers = new double[randomParameterSets][];
-            for (int i = 0; i < randomParameterSets; i++)
-            {
-                randomChallengers[i] = CreateParameterSet();
-            }
+            var randomChallengers = SampleRandomParameterSets(randomParameterSets);
 
             // Interleave challengers and random parameter sets.
             return InterLeaveModelBasedAndRandomParameterSets(challengers, randomChallengers);
@@ -173,7 +165,7 @@ namespace SharpLearning.Optimization
             // Additional set of random parameterSets to choose from during local search.
             for (int i = 0; i < m_randomEISearchParameterSetsCount; i++)
             {
-                var parameterSet = CreateParameterSet();
+                var parameterSet = SampleParameterSet();
                 var ei = ComputeExpectedImprovement(best, parameterSet, model);
                 parameterSets.Add((parameterSet, ei));
             }
@@ -257,17 +249,28 @@ namespace SharpLearning.Optimization
             return AcquisitionFunctions.ExpectedImprovement(best, mean, variance);
         }
 
-        double[] CreateParameterSet()
+        double[][] SampleRandomParameterSets(int parameterSetCount)
         {
-            var newPoint = new double[m_parameters.Length];
+            var parameterSets = new double[parameterSetCount][];
+            for (int i = 0; i < parameterSetCount; i++)
+            {
+                parameterSets[i] = SampleParameterSet();
+            }
+
+            return parameterSets;
+        }
+
+        double[] SampleParameterSet()
+        {
+            var parameterSet = new double[m_parameters.Length];
 
             for (int i = 0; i < m_parameters.Length; i++)
             {
                 var parameter = m_parameters[i];
-                newPoint[i] = parameter.SampleValue(m_sampler);
+                parameterSet[i] = parameter.SampleValue(m_sampler);
             }
 
-            return newPoint;
+            return parameterSet;
         }
     }
 }

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -21,6 +21,7 @@ namespace SharpLearning.Optimization
         readonly IParameterSpec[] m_parameters;
         readonly int m_iterations;
         readonly int m_randomStartingPointsCount;
+        readonly int m_functionEvaluationsPerIterationCount;
         readonly int m_localSearchPointCount;
         readonly int m_randomSearchPointCount;
 
@@ -38,7 +39,9 @@ namespace SharpLearning.Optimization
         /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
         /// <param name="iterations">The number of iterations to perform</param>
         /// <param name="randomStartingPointCount">Number of randomly parameter sets used 
-        /// for initialization (default is 10)</param>
+        /// for initialization (default is 20)</param>
+        /// <param name="functionEvaluationsPerIterationCount">The number of function evaluations per iteration. 
+        /// (default is 1).</param>
         /// <param name="localSearchPointCount">The number of top contenders 
         /// to use in the greedy local search (default is (10)</param>
         /// <param name="randomSearchPointCount">The number of random parameter sets
@@ -46,7 +49,8 @@ namespace SharpLearning.Optimization
         /// <param name="seed"></param>
         public SmacOptimizer(IParameterSpec[] parameters,
             int iterations,
-            int randomStartingPointCount = 10, 
+            int randomStartingPointCount = 20,
+            int functionEvaluationsPerIterationCount = 1,
             int localSearchPointCount = 10,
             int randomSearchPointCount = 1000,
             int seed = 42)
@@ -59,6 +63,7 @@ namespace SharpLearning.Optimization
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             m_iterations = iterations;
             m_randomStartingPointsCount = randomStartingPointCount;
+            m_functionEvaluationsPerIterationCount = functionEvaluationsPerIterationCount;
             m_localSearchPointCount = localSearchPointCount;
             m_randomSearchPointCount = randomSearchPointCount;
 
@@ -90,7 +95,7 @@ namespace SharpLearning.Optimization
 
             for (int iteration = 0; iteration < m_iterations; iteration++)
             {
-                var parameterSets = ProposeParameterSets(1, results);
+                var parameterSets = ProposeParameterSets(m_functionEvaluationsPerIterationCount, results);
                 RunParameterSets(functionToMinimize, parameterSets, results);
             }
 

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SharpLearning.Containers.Extensions;
+using SharpLearning.Optimization.ParameterSamplers;
+using SharpLearning.RandomForest.Learners;
+using SharpLearning.RandomForest.Models;
+
+namespace SharpLearning.Optimization
+{
+    public class SmacOptimizer : IOptimizer
+    {
+        readonly Random m_random;
+        readonly IParameterSampler m_sampler;
+        readonly IParameterSpec[] m_parameters;
+        readonly int m_iterationCount;
+        readonly int m_startConfigurationCount;
+        readonly int m_localSearchCount;
+        readonly int m_randomEISearchConfigurationsCount;
+
+        // Important to use extra trees learner to have split between features calculated as: 
+        // m_random.NextDouble() * (max - min) + min; 
+        // instead of: (currentValue + prevValue) * 0.5; like in random forest.
+        readonly RegressionExtremelyRandomizedTreesLearner m_learner;
+
+        public SmacOptimizer(IParameterSpec[] parameters,
+            int iterationCount = 10,
+            int startConfigurationCount = 20, 
+            int localSearchParentCount = 10,
+            int randomEISearchConfigurationsCount = 10000,
+            int seed = 42)
+        {
+            m_random = new Random(seed);
+            // Use member to seed the random uniform sampler.
+            m_sampler = new RandomUniform(m_random.Next());
+            m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+            m_iterationCount = iterationCount;
+            m_startConfigurationCount = startConfigurationCount;
+            m_localSearchCount = localSearchParentCount;
+            m_randomEISearchConfigurationsCount = randomEISearchConfigurationsCount;
+
+            // Hyper parameters for regression extra trees learner. These are based on the values suggested in http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf.
+            // However, according to the author Frank Hutter, the hyper parameters for the forest model should not matter that much.
+            m_learner = new RegressionExtremelyRandomizedTreesLearner(trees: 30,
+                minimumSplitSize: 2,
+                maximumTreeDepth: 2000,
+                featuresPrSplit: parameters.Length,
+                minimumInformationGain: 1e-6,
+                subSampleRatio: 1.0,
+                seed: m_random.Next(), // Use member to seed the random uniform sampler.
+                runParallel: false);
+        }
+
+
+        public OptimizerResult[] Optimize(Func<double[], OptimizerResult> functionToMinimize)
+        {
+            var initialConfigurations = SelectConfigurations(m_startConfigurationCount, null);
+
+            // Initialize the search
+            var results = new List<OptimizerResult>();
+            RunConfigurations(functionToMinimize, initialConfigurations, results);
+
+            for (int iteration = 0; iteration < m_iterationCount; iteration++)
+            {
+                var configurations = SelectConfigurations(5, results);
+                RunConfigurations(functionToMinimize, configurations, results);
+            }
+
+            // return all results ordered
+            return results.ToArray();
+        }
+
+        public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) => 
+            // Return the best model found.
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
+
+        void RunConfigurations(Func<double[], OptimizerResult> functionToMinimize, 
+            double[][] configurations, List<OptimizerResult> results)
+        {
+            foreach (var configuration in configurations)
+            {
+                // Get the current parameters for the current point
+                var result = functionToMinimize(configuration);
+                results.Add(result);
+            }
+        }
+
+        double[][] SelectConfigurations(int configurationCount, 
+            IReadOnlyList<OptimizerResult> previousRuns = null)
+        {
+            var configurations = previousRuns == null ? 0 : previousRuns.Count;
+            if (configurations < m_startConfigurationCount)
+            {
+                var randomConfigurationCount = Math.Min(configurationCount, 
+                    m_startConfigurationCount - configurations);
+
+                var randomConfigurations = new double[randomConfigurationCount][];
+                for (int i = 0; i < randomConfigurationCount; i++)
+                {
+                    randomConfigurations[i] = CreateParameterSet();
+                }
+
+                return randomConfigurations;
+            }
+
+            var validConfigurations = previousRuns.Where(v => !double.IsNaN(v.Error));
+
+            // fit model
+            var observations = validConfigurations
+                .Select(v => v.ParameterSet).ToList()
+                .ToF64Matrix();
+
+            var targets = validConfigurations
+                .Select(v => v.Error).ToArray();
+
+            var model = m_learner.Learn(observations, targets);
+
+            return GenerateCandidateConfigurations(configurations, validConfigurations.ToList(), model);
+        }
+
+        double[][] GenerateCandidateConfigurations(int configurationCount, IReadOnlyList<OptimizerResult> previousRuns, RegressionForestModel model)
+        {
+            // Get k best previous runs ParameterSets.
+            var bestKParamSets = previousRuns.OrderBy(v => v.Error)
+                .Take(m_localSearchCount).Select(v => v.ParameterSet).ToArray();
+            
+            // Perform local searches using the k best previous run configurations.
+            var eiChallengers = GreedyPlusRandomSearch(bestKParamSets, model, 
+                (int)Math.Ceiling(configurationCount / 2.0F), previousRuns);
+
+            // Generate another set of random configurations to interleave.
+            var randomConfigurations = configurationCount - eiChallengers.Length;
+            var randomChallengers = new double[randomConfigurations][];
+            for (int i = 0; i < randomConfigurations; i++)
+            {
+                randomChallengers[i] = CreateParameterSet();
+            }
+
+            // Return interleaved challenger candidates with random candidates. Since the number of candidates from either can be less than
+            // the number asked for, since we only generate unique candidates, and the number from either method may vary considerably.
+            var finalConfigurations = new double[eiChallengers.Length + randomChallengers.Length][];
+            Array.Copy(eiChallengers, 0, finalConfigurations, 0, eiChallengers.Length);
+            Array.Copy(randomChallengers, 0, finalConfigurations, eiChallengers.Length, randomChallengers.Length);
+
+            return finalConfigurations;
+        }
+
+        double[][] GreedyPlusRandomSearch(double[][] parentConfigurations, RegressionForestModel model, 
+            int configurationCount, IReadOnlyList<OptimizerResult> previousRuns)
+        {
+            // TODO: Handle maximization and minimization. Currently minimizes.
+            var best = previousRuns.Min(v => v.Error);
+            var worst = previousRuns.Max(v => v.Error);
+
+            var configurations = new List<(double[] configuration, double EI)>();
+            // Perform local search.
+            foreach (var configuration in parentConfigurations)
+            {
+                var bestChildConfig = LocalSearch(parentConfigurations, model, best, epsilon: 0.00001);
+                configurations.Add(bestChildConfig);
+            }
+
+            // Additional set of random configurations to choose from during local search.
+            for (int i = 0; i < m_randomEISearchConfigurationsCount; i++)
+            {
+                var configuration = CreateParameterSet();
+                var ei = ComputeExpectedImprovement(best, configuration, model);
+                configurations.Add((configuration, ei));
+            }
+
+            // take best configurations. Here we want the max expected improvement).
+            return configurations.OrderByDescending(v => v.EI)
+                .Take(configurationCount).Select(v => v.configuration).ToArray();
+        }
+
+        /// <summary>
+        /// Performs a local one-mutation neighborhood greedy search.
+        /// </summary>
+        /// <param name="parentConfigurations">Starting parameter set configuration.</param>
+        /// <param name="model">Trained forest, for evaluation of points.</param>
+        /// <param name="bestVal">Best performance seen thus far.</param>
+        /// <param name="epsilon">Threshold for when to stop the local search.</param>
+        /// <returns></returns>
+        (double[] configuration, double bestEI) LocalSearch(double[][] parentConfigurations, 
+            RegressionForestModel model, double bestVal, double epsilon)
+        {
+            var currentBestConfig = parentConfigurations.First();
+            var currentBestEI = ComputeExpectedImprovement(bestVal, currentBestConfig, model);
+
+            // TODO: clean up loop.
+            var newBest = true;
+            while (true)
+            {
+                // Stop search of no neighbors improve EI.
+                if(newBest)
+                {
+                    newBest = false;
+                }
+                else
+                {
+                    break;
+                }
+
+                var neighborhood = GetOneMutationNeighborhood(currentBestConfig);
+                for (int i = 0; i < neighborhood.Count; i++)
+                {
+                    var neighbor = neighborhood[i];
+                    var ei = ComputeExpectedImprovement(bestVal, neighbor, model);
+                    // TODO: Determine correct comparison. We want the largest possible expected improvement.
+                    if (ei - currentBestEI < epsilon)
+                    {
+                    }
+                    else
+                    {
+                        currentBestConfig = neighbor;
+                        currentBestEI = ei;
+                        newBest = true;
+                    }
+                }
+            }
+
+            return (currentBestConfig, currentBestEI);
+        }
+
+        List<double[]> GetOneMutationNeighborhood(double[] parentConfiguration)
+        {
+            var neighbors = new List<double[]>();
+
+            for (int i = 0; i < m_parameters.Length; i++)
+            {
+                // Add a new configuration that differs by one parameter from the parent.
+                var parameterSpec = m_parameters[i];
+
+                // Add 4 configurations pr. parameter
+                const int configurationCount = 4;
+                for (int j = 0; j < configurationCount; j++)
+                {
+                    // Copy parant and mutate one parameter.
+                    var newConfiguration = parentConfiguration.ToArray();
+                    newConfiguration[i] = parameterSpec.SampleValue(m_sampler);
+                    neighbors.Add(newConfiguration);
+                }
+            }
+
+            return neighbors;
+        }
+
+        double ComputeExpectedImprovement(double best, double[] configuration, RegressionForestModel model)
+        {
+            var prediction = model.PredictCertainty(configuration);
+            var mean = prediction.Prediction;
+            var variance = prediction.Variance;
+            return AcquisitionFunctions.ExpectedImprovement(best, mean, variance);
+        }
+
+        double[] CreateParameterSet()
+        {
+            var newPoint = new double[m_parameters.Length];
+
+            for (int i = 0; i < m_parameters.Length; i++)
+            {
+                var parameter = m_parameters[i];
+                newPoint[i] = parameter.SampleValue(m_sampler);
+            }
+
+            return newPoint;
+        }
+    }
+}

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -218,7 +218,6 @@ namespace SharpLearning.Optimization
         List<double[]> GetOneMutationNeighborhood(double[] parentParameterSet)
         {
             var neighbors = new List<double[]>();
-
             for (int i = 0; i < m_parameters.Length; i++)
             {
                 // Add a new parameter set that differs only by one parameter from the parent.
@@ -231,7 +230,7 @@ namespace SharpLearning.Optimization
                 const int parameterSetCount = 4;
                 for (int j = 0; j < parameterSetCount; j++)
                 {
-                    // Copy parant and mutate one parameter.
+                    // Copy parent and mutate one parameter.
                     var newParameterSet = parentParameterSet.ToArray();
                     newParameterSet[i] = parameterSpec.SampleValue(m_sampler);
                     neighbors.Add(newParameterSet);

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -53,6 +53,9 @@ namespace SharpLearning.Optimization
                 runParallel: false);
         }
 
+        public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) =>
+            // Return the best model found.
+            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         public OptimizerResult[] Optimize(Func<double[], OptimizerResult> functionToMinimize)
         {
@@ -71,10 +74,6 @@ namespace SharpLearning.Optimization
             // return all results ordered
             return results.ToArray();
         }
-
-        public OptimizerResult OptimizeBest(Func<double[], OptimizerResult> functionToMinimize) => 
-            // Return the best model found.
-            Optimize(functionToMinimize).Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
 
         void RunParameterSets(Func<double[], OptimizerResult> functionToMinimize, 
             double[][] parameterSets, List<OptimizerResult> results)

--- a/src/SharpLearning.RandomForest.Test/SharpLearning.RandomForest.Test.csproj
+++ b/src/SharpLearning.RandomForest.Test/SharpLearning.RandomForest.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/src/SharpLearning.XGBoost.Test/SharpLearning.XGBoost.Test.csproj
+++ b/src/SharpLearning.XGBoost.Test/SharpLearning.XGBoost.Test.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>


### PR DESCRIPTION
This pull request adds the `SmacOptimizer` to `SharpLearning.Optimization`. The implementation is based on the paper: [Sequential Model-Based Optimization for General Algorithm Configuration](https://ml.informatik.uni-freiburg.de/papers/11-LION5-SMAC.pdf).

The algorithm combines bayesian optimization with greedy local search based on the current top solutions.

The `SmacOptimizer` implements the regular `IOptimizer` interface, but also surfaces the two primary methods for running the algorithm `ProposeParameterSets` and `RunParameterSets`. This makes it possible to use the optimizer in an "open-loop" style, and allows the optimizer to be easily used from or combined with other optimizers. An examples could be using the scheduling technique from the `HyberbandOptimizer` together with the model based sampling from the `SmacOptimizer`.

An example showing "open-loop" use can be found in the `SmacOptimizerTest` class.