### PR TITLE
Add azure pipelines yaml configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 SharpLearning
 =================
 
-![Build status](https://machinelearning.visualstudio.com/sharplearning-github-build/_apis/build/status/SharpLearning-CI-Build?branchName=master)
+![Build status](https://machinelearning.visualstudio.com/sharplearning-github-build/_apis/build/status/SharpLearning-CI?branchName=master)
 
 SharpLearning is an opensource machine learning library for C# .Net. 
 The goal of SharpLearning is to provide .Net developers with easy access to machine learning algorithms and models.

--- a/SharpLearning.sln
+++ b/SharpLearning.sln
@@ -55,6 +55,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpLearning.InputOutput",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{55C8F585-6918-4373-A349-EDF167D77FBB}"
 	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yaml = azure-pipelines.yaml
 		CONTRIBUTING.md = CONTRIBUTING.md
 		src\Directory.Build.props = src\Directory.Build.props
 		README.md = README.md

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -64,6 +64,5 @@ jobs:
       packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
       nuGetFeedType: external
       publishFeedCredentials: 'nuget/mdabros Api'
-	  allowPackageConflicts: true
     enabled: true
     condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['buildConfiguration'], 'Release')

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -2,7 +2,7 @@ trigger:
   - master
 
 variables:
-  buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU')
+  #buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU')
   testAssembliesSearchPattern: 'BuildTest\**\*Test.dll'
   
 jobs:
@@ -30,14 +30,14 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '--configuration $(buildConfiguration) /p:Platform $(buildPlatform)'
+      arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
     displayName: Test
     inputs:
       command: test
       projects: '$(testAssembliesSearchPattern)'
-      arguments: '--configuration $(buildConfiguration) /p:Platform $(buildPlatform)'
+      arguments: '--configuration $(buildConfiguration)'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet pack'
@@ -53,4 +53,4 @@ jobs:
   #    nuGetFeedType: external
   #    publishFeedCredentials: 'nuget/mdabros Api'
   #  enabled: false
-  #  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #  condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['buildConfiguration'], 'Release')

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -2,8 +2,7 @@ trigger:
   - master
 
 variables:
-  cleanOnCheckout: true
-  buildPlatform 'AnyCPU' # specify platform ('x86', 'x64', 'AnyCPU')
+  buildPlatform: 'AnyCPU' # specify platform ('x86', 'x64', 'AnyCPU')
   testAssembliesSearchPattern: 'BuildTest\**\*Test.dll'
   
 jobs:
@@ -18,45 +17,45 @@ jobs:
     - Cmd
     
   strategy:
-    marix:
+    matrix:
       Debug:
         buildConfiguration: 'Debug'
       Release:
         buildConfiguration: 'Release'
         
-steps:
-- task: DotNetCoreCLI@2
-  displayName: Restore
-  inputs:
-    command: 'restore'
-    projects: '**/*.csproj'
+  steps:
+  - task: DotNetCoreCLI@2
+    displayName: Restore
+    inputs:
+      command: 'restore'
+      projects: '**/*.csproj'
 
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    command: build
-    projects: '**/*.csproj'
-    arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      command: build
+      projects: '**/*.csproj'
+      arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
 
-- task: DotNetCoreCLI@2
-  displayName: Test
-  inputs:
-    command: test
-    projects: '$(testAssembliesSearchPattern)'
-    arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
+  - task: DotNetCoreCLI@2
+    displayName: Test
+    inputs:
+      command: test
+      projects: '$(testAssembliesSearchPattern)'
+      arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet pack'
-  inputs:
-    command: pack
-    packagesToPack: '**/*.csproj;-:**/*.Test.csproj'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet pack'
+    inputs:
+      command: pack
+      packagesToPack: '**/*.csproj;-:**/*.Test.csproj'
 
-#- task: NuGetCommand@2
-#  displayName: 'NuGet push'
-#  inputs:
-#    command: push
-#    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-#    nuGetFeedType: external
-#    publishFeedCredentials: 'nuget/mdabros Api'
-#  enabled: false
-#  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #- task: NuGetCommand@2
+  #  displayName: 'NuGet push'
+  #  inputs:
+  #    command: push
+  #    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+  #    nuGetFeedType: external
+  #    publishFeedCredentials: 'nuget/mdabros Api'
+  #  enabled: false
+  #  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,6 +1,13 @@
 trigger:
   - master
 
+  # Specify that pull request validation is enabled for all branches (this is also default),
+  # but added to make it easy to change to master only of necesarry.
+  pr: 
+  branches:
+    include:
+    - '*'  # must quote since "*" is a YAML reserved character; we want a string
+
 variables:
   #buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU')
   testProjectsSearchPattern: '**/*.Test.csproj'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,11 +10,6 @@ jobs:
   displayName: 'CI'
   pool:
     name: Hosted VS2017
-    demands:
-    - msbuild
-    - visualstudio
-    - vstest
-    - Cmd
     
   strategy:
     matrix:
@@ -35,14 +30,14 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
+      arguments: '--configuration $(buildConfiguration) /Platform $(buildPlatform)'
 
   - task: DotNetCoreCLI@2
     displayName: Test
     inputs:
       command: test
       projects: '$(testAssembliesSearchPattern)'
-      arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
+      arguments: '--configuration $(buildConfiguration) /Platform $(buildPlatform)'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet pack'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,15 +1,13 @@
+# Trigger CI only on master branch.
 trigger:
   - master
 
-  # Specify that pull request validation is enabled for all branches (this is also default),
-  # but added to make it easy to change to master only of necesarry.
-  pr: 
-  branches:
-    include:
-    - '*'  # must quote since "*" is a YAML reserved character; we want a string
+# Pull request validation against master branch only.
+pr: 
+  - master
 
 variables:
-  #buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU')
+  #buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU').
   testProjectsSearchPattern: '**/*.Test.csproj'
   
 jobs:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -52,12 +52,13 @@ jobs:
       command: pack
       packagesToPack: '**/*.csproj;-:**/*.Test.csproj'
 
-  #- task: NuGetCommand@2
-  #  displayName: 'NuGet push'
-  #  inputs:
-  #    command: push
-  #    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-  #    nuGetFeedType: external
-  #    publishFeedCredentials: 'nuget/mdabros Api'
-  #  enabled: false
-  #  condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['buildConfiguration'], 'Release')
+  - task: NuGetCommand@2
+    displayName: 'NuGet push'
+    inputs:
+      command: push
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+      nuGetFeedType: external
+      publishFeedCredentials: 'nuget/mdabros Api'
+	  allowPackageConflicts: true
+    enabled: true
+    condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['buildConfiguration'], 'Release')

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -30,14 +30,14 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '--configuration $(buildConfiguration) /Platform $(buildPlatform)'
+      arguments: '--configuration $(buildConfiguration) /p:Platform $(buildPlatform)'
 
   - task: DotNetCoreCLI@2
     displayName: Test
     inputs:
       command: test
       projects: '$(testAssembliesSearchPattern)'
-      arguments: '--configuration $(buildConfiguration) /Platform $(buildPlatform)'
+      arguments: '--configuration $(buildConfiguration) /p:Platform $(buildPlatform)'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet pack'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,0 +1,62 @@
+trigger:
+  - master
+
+variables:
+  cleanOnCheckout: true
+  buildPlatform 'AnyCPU' # specify platform ('x86', 'x64', 'AnyCPU')
+  testAssembliesSearchPattern: 'BuildTest\**\*Test.dll'
+  
+jobs:
+- job: 'CI'
+  displayName: 'CI'
+  pool:
+    name: Hosted VS2017
+    demands:
+    - msbuild
+    - visualstudio
+    - vstest
+    - Cmd
+    
+  strategy:
+    marix:
+      Debug:
+        buildConfiguration: 'Debug'
+      Release:
+        buildConfiguration: 'Release'
+        
+steps:
+- task: DotNetCoreCLI@2
+  displayName: Restore
+  inputs:
+    command: 'restore'
+    projects: '**/*.csproj'
+
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    command: build
+    projects: '**/*.csproj'
+    arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
+
+- task: DotNetCoreCLI@2
+  displayName: Test
+  inputs:
+    command: test
+    projects: '$(testAssembliesSearchPattern)'
+    arguments: '--configuration $(buildConfiguration) --Platform $(buildPlatform)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack'
+  inputs:
+    command: pack
+    packagesToPack: '**/*.csproj;-:**/*.Test.csproj'
+
+#- task: NuGetCommand@2
+#  displayName: 'NuGet push'
+#  inputs:
+#    command: push
+#    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+#    nuGetFeedType: external
+#    publishFeedCredentials: 'nuget/mdabros Api'
+#  enabled: false
+#  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -65,4 +65,4 @@ jobs:
       nuGetFeedType: external
       publishFeedCredentials: 'nuget/mdabros Api'
     enabled: true
-    condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['buildConfiguration'], 'Release')
+    condition: and(and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(variables['buildConfiguration'], 'Release'))

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -3,7 +3,7 @@ trigger:
 
 variables:
   #buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU')
-  testAssembliesSearchPattern: 'BuildTest\**\*Test.dll'
+  testProjectsSearchPattern: '**/*.Test.csproj'
   
 jobs:
 - job: 'CI'
@@ -36,8 +36,15 @@ jobs:
     displayName: Test
     inputs:
       command: test
-      projects: '$(testAssembliesSearchPattern)'
-      arguments: '--configuration $(buildConfiguration)'
+      projects: '$(testProjectsSearchPattern)'
+      arguments: '--configuration $(BuildConfiguration)'
+
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    condition: succeededOrFailed()
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: '**/*.trx'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet pack'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -2,7 +2,7 @@ trigger:
   - master
 
 variables:
-  buildPlatform: 'AnyCPU' # specify platform ('x86', 'x64', 'AnyCPU')
+  buildPlatform: 'Any CPU' # specify platform ('x86', 'x64', 'Any CPU')
   testAssembliesSearchPattern: 'BuildTest\**\*Test.dll'
   
 jobs:


### PR DESCRIPTION
This pull request adds `azure-pipelines.yaml` configuration to control CI and PR validation. This also adds both debug and release validation. Previously, only the release version was build and tested via CI. 

This addition is the bare minimum of the yaml configuration. BuildPlatform has not been added to the configuration yet. I could not make it work together with the dotnet build command. Information on this can be found here: [dotnet issue 10421](https://github.com/dotnet/cli/issues/10421). So currently, the build platform from the project files is used.

I am currently using 'tasks' for the individual steps, but it seems that 'scripts' are generally more popular for dotnet core pipelines. Here is a guide using scripts: [yaml-build-pipeline-net-core-azure-devops-tutorial)](https://www.nankov.com/posts/yaml-build-pipeline-net-core-azure-devops-tutorial)

Another example is the [TorchSharp pipeline](https://github.com/xamarin/TorchSharp/blob/master/azure-pipelines.yml), but that also handles additional steps for getting external resources etc.. 'Scripts' definitely seems more flexible than 'tasks', so I might switch to 'scripts' in the future when I have some more experience with them.