### PR TITLE
Make SharpLearning.Neural support .net core 2.0/.net standard 2.0 (update mathnet numerics to latest version (.NETStandard 2.0 compatible) )

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.31.1.0</Version>
-    <AssemblyVersion>0.31.1.0</AssemblyVersion>
-    <FileVersion>0.31.1.0</FileVersion>
+	  <Version>0.31.2.0</Version>
+    <AssemblyVersion>0.31.2.0</AssemblyVersion>
+    <FileVersion>0.31.2.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
+++ b/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="3.17.0" />
-    <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.2.0" />
+    <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
+    <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/src/SharpLearning.Neural/SharpLearning.Neural.csproj
+++ b/src/SharpLearning.Neural/SharpLearning.Neural.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="3.17.0" />
-    <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.2.0" />
+    <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
+    <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates mathnet numerics to latest version (.NETStandard 2.0 compatible). This enables SharpLearning.Neural to have support for .net core 2.0/.net standard 2.0, and solves #26. 