### PR TITLE
0.31.4.0: Add CrossValidationUtilities.GetKFoldCrossValidationIndexSets, Refactor CrossValidation.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.31.3.0</Version>
-    <AssemblyVersion>0.31.3.0</AssemblyVersion>
-    <FileVersion>0.31.3.0</FileVersion>
+	  <Version>0.31.4.0</Version>
+    <AssemblyVersion>0.31.4.0</AssemblyVersion>
+    <FileVersion>0.31.4.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
@@ -16,12 +16,14 @@ namespace SharpLearning.CrossValidation.Test
             var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler,
                 foldCount: 4, targets: targets);
 
+            TraceIndexSets(actuals);
+
             var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
             {
                 (new int[] { 0, 1, 3, 4, 5, 7, 9, 10, 11 }, new int[] { 6, 8, 2 }),
                 (new int[] { 0, 2, 3, 4, 6, 7, 8, 9, 10 }, new int[] { 1, 11, 5 }),
                 (new int[] { 0, 1, 2, 4, 5, 6, 8, 9, 11 }, new int[] { 7, 3, 10 }),
-                (new int[] { 1, 2, 3, 5, 6, 7, 8, 10, 11 }, new int[] { 9, 0, 4 }),
+                (new int[] { 1, 2, 3, 5, 6, 7, 8, 10, 11 }, new int[] { 0, 4, 9 }),
             };
 
             Assert.AreEqual(expecteds.Count, actuals.Count);

--- a/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpLearning.CrossValidation.Samplers;
+
+namespace SharpLearning.CrossValidation.Test
+{
+    [TestClass]
+    public class CrossValidationUtilitiesTest
+    {
+        [TestMethod]
+        public void CrossValidationUtilities_GetCrossValidationIndexSets()
+        {
+            var targets = new double[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3 };
+            var sampler = new StratifiedIndexSampler<double>(seed: 242);
+            var actuals = CrossValidationUtilities.GetCrossValidationIndexSets(sampler, 
+                foldCount: 4, targets: targets);
+
+            var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
+            {
+                (new int[] { 0, 1, 2, 3, 5, 6, 7, 9, 11, 12, 13, 14 }, new int[] { 10, 4, 8 }),
+                (new int[] { 0, 1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 }, new int[] { 2, 7, 14 }),
+                (new int[] { 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 14 }, new int[] { 5, 13, 0 }),
+                (new int[] { 0, 1, 2, 4, 5, 7, 8, 9, 10, 12, 13, 14 }, new int[] { 6, 11, 3 }),
+            };
+
+            Assert.AreEqual(expecteds.Count, actuals.Count);
+            for (int i = 0; i < expecteds.Count; i++)
+            {
+                var expected = expecteds[i];
+                var actual = actuals[i];
+                CollectionAssert.AreEqual(expected.trainingIndices, actual.trainingIndices);
+                CollectionAssert.AreEqual(expected.validationIndices, actual.validationIndices);
+            }
+        }
+
+        void TraceIndexSets(List<(int[] trainingIndices, int[] validationIndices)> indexSets)
+        {
+            const string Separator = ", ";
+            foreach (var set in indexSets)
+            {
+                Trace.WriteLine("(new int[] { " + string.Join(Separator, set.trainingIndices) + " }, " +
+                    "new int[] { " + string.Join(Separator, set.validationIndices) + " }),");
+            }
+        }
+    }
+}

--- a/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
@@ -62,8 +62,35 @@ namespace SharpLearning.CrossValidation.Test
             }
         }
 
+        [TestMethod]
+        public void CrossValidationUtilities_GetCrossValidationIndexSets_Indices()
+        {
+            var targets = new double[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3 };
+            var indices = new int[] { 0, 1, 2, 3, 4, 5, 6 };
+            var sampler = new StratifiedIndexSampler<double>(seed: 242);
+            var actuals = CrossValidationUtilities.GetCrossValidationIndexSets(sampler,
+                foldCount: 2, targets: targets, indices: indices);
 
-        void TraceIndexSets(List<(int[] trainingIndices, int[] validationIndices)> indexSets)
+            TraceIndexSets(actuals);
+
+            var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
+            {
+                // Sets contains values from the indices array only.
+                (new int[] { 1, 3, 4, 5 }, new int[] { 2, 6, 0 }),
+                (new int[] { 0, 2, 6 }, new int[] { 1, 3, 4, 5 }),
+            };
+
+            Assert.AreEqual(expecteds.Count, actuals.Count);
+            for (int i = 0; i < expecteds.Count; i++)
+            {
+                var expected = expecteds[i];
+                var actual = actuals[i];
+                CollectionAssert.AreEqual(expected.trainingIndices, actual.trainingIndices);
+                CollectionAssert.AreEqual(expected.validationIndices, actual.validationIndices);
+            }
+        }
+
+        void TraceIndexSets(IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> indexSets)
         {
             const string Separator = ", ";
             foreach (var set in indexSets)

--- a/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
@@ -9,37 +9,9 @@ namespace SharpLearning.CrossValidation.Test
     public class CrossValidationUtilitiesTest
     {
         [TestMethod]
-        public void CrossValidationUtilities_GetKFoldCrossValidationIndexSets_Handle_Remainder()
-        {
-            var targets = new double[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3 };
-            var sampler = new StratifiedIndexSampler<double>(seed: 242);
-            var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler, 
-                foldCount: 4, targets: targets);
-
-            var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
-            {
-                (new int[] { 0, 1, 2, 3, 5, 6, 7, 9, 11, 12, 13, 14 }, new int[] { 10, 4, 8 }),
-                (new int[] { 0, 1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 }, new int[] { 2, 7, 14 }),
-                (new int[] { 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 14 }, new int[] { 5, 13, 0 }),
-                // Handle remainder from target.length / foldsCount, 
-                // by adding remaining indices to the last set
-                (new int[] { 0, 2, 4, 5, 7, 8, 10, 13, 14 }, new int[] { 1, 3, 6, 9, 11, 12 }),
-            };
-
-            Assert.AreEqual(expecteds.Count, actuals.Count);
-            for (int i = 0; i < expecteds.Count; i++)
-            {
-                var expected = expecteds[i];
-                var actual = actuals[i];
-                CollectionAssert.AreEqual(expected.trainingIndices, actual.trainingIndices);
-                CollectionAssert.AreEqual(expected.validationIndices, actual.validationIndices);
-            }
-        }
-
-        [TestMethod]
         public void CrossValidationUtilities_GetKFoldCrossValidationIndexSets()
         {
-            var targets = new double[] { 1, 1, 1, 1 , 2, 2, 2, 2, 3, 3, 3, 3 };
+            var targets = new double[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3 };
             var sampler = new StratifiedIndexSampler<double>(seed: 242);
             var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler,
                 foldCount: 4, targets: targets);
@@ -78,6 +50,34 @@ namespace SharpLearning.CrossValidation.Test
                 // Sets contains values from the indices array only.
                 (new int[] { 1, 3, 4, 5 }, new int[] { 2, 6, 0 }),
                 (new int[] { 0, 2, 6 }, new int[] { 1, 3, 4, 5 }),
+            };
+
+            Assert.AreEqual(expecteds.Count, actuals.Count);
+            for (int i = 0; i < expecteds.Count; i++)
+            {
+                var expected = expecteds[i];
+                var actual = actuals[i];
+                CollectionAssert.AreEqual(expected.trainingIndices, actual.trainingIndices);
+                CollectionAssert.AreEqual(expected.validationIndices, actual.validationIndices);
+            }
+        }
+
+        [TestMethod]
+        public void CrossValidationUtilities_GetKFoldCrossValidationIndexSets_Handle_Remainder()
+        {
+            var targets = new double[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3 };
+            var sampler = new StratifiedIndexSampler<double>(seed: 242);
+            var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler, 
+                foldCount: 4, targets: targets);
+
+            var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
+            {
+                (new int[] { 0, 1, 2, 3, 5, 6, 7, 9, 11, 12, 13, 14 }, new int[] { 10, 4, 8 }),
+                (new int[] { 0, 1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 }, new int[] { 2, 7, 14 }),
+                (new int[] { 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 14 }, new int[] { 5, 13, 0 }),
+                // Handle remainder from target.length / foldsCount, 
+                // by adding remaining indices to the last set
+                (new int[] { 0, 2, 4, 5, 7, 8, 10, 13, 14 }, new int[] { 1, 3, 6, 9, 11, 12 }),
             };
 
             Assert.AreEqual(expecteds.Count, actuals.Count);

--- a/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
@@ -9,7 +9,7 @@ namespace SharpLearning.CrossValidation.Test
     public class CrossValidationUtilitiesTest
     {
         [TestMethod]
-        public void CrossValidationUtilities_GetCrossValidationIndexSets()
+        public void CrossValidationUtilities_GetCrossValidationIndexSets_Handle_Remainder()
         {
             var targets = new double[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3 };
             var sampler = new StratifiedIndexSampler<double>(seed: 242);
@@ -21,7 +21,9 @@ namespace SharpLearning.CrossValidation.Test
                 (new int[] { 0, 1, 2, 3, 5, 6, 7, 9, 11, 12, 13, 14 }, new int[] { 10, 4, 8 }),
                 (new int[] { 0, 1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13 }, new int[] { 2, 7, 14 }),
                 (new int[] { 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 14 }, new int[] { 5, 13, 0 }),
-                (new int[] { 0, 1, 2, 4, 5, 7, 8, 9, 10, 12, 13, 14 }, new int[] { 6, 11, 3 }),
+                // Handle remainder from target.length / foldsCount, 
+                // by adding remaining indices to the last set
+                (new int[] { 0, 2, 4, 5, 7, 8, 10, 13, 14 }, new int[] { 1, 3, 6, 9, 11, 12 }),
             };
 
             Assert.AreEqual(expecteds.Count, actuals.Count);
@@ -33,6 +35,33 @@ namespace SharpLearning.CrossValidation.Test
                 CollectionAssert.AreEqual(expected.validationIndices, actual.validationIndices);
             }
         }
+
+        [TestMethod]
+        public void CrossValidationUtilities_GetCrossValidationIndexSets()
+        {
+            var targets = new double[] { 1, 1, 1, 1 , 2, 2, 2, 2, 3, 3, 3, 3 };
+            var sampler = new StratifiedIndexSampler<double>(seed: 242);
+            var actuals = CrossValidationUtilities.GetCrossValidationIndexSets(sampler,
+                foldCount: 4, targets: targets);
+
+            var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
+            {
+                (new int[] { 0, 1, 3, 4, 5, 7, 9, 10, 11 }, new int[] { 6, 8, 2 }),
+                (new int[] { 0, 2, 3, 4, 6, 7, 8, 9, 10 }, new int[] { 1, 11, 5 }),
+                (new int[] { 0, 1, 2, 4, 5, 6, 8, 9, 11 }, new int[] { 7, 3, 10 }),
+                (new int[] { 1, 2, 3, 5, 6, 7, 8, 10, 11 }, new int[] { 9, 0, 4 }),
+            };
+
+            Assert.AreEqual(expecteds.Count, actuals.Count);
+            for (int i = 0; i < expecteds.Count; i++)
+            {
+                var expected = expecteds[i];
+                var actual = actuals[i];
+                CollectionAssert.AreEqual(expected.trainingIndices, actual.trainingIndices);
+                CollectionAssert.AreEqual(expected.validationIndices, actual.validationIndices);
+            }
+        }
+
 
         void TraceIndexSets(List<(int[] trainingIndices, int[] validationIndices)> indexSets)
         {

--- a/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
+++ b/src/SharpLearning.CrossValidation.Test/CrossValidationUtilitiesTest.cs
@@ -9,11 +9,11 @@ namespace SharpLearning.CrossValidation.Test
     public class CrossValidationUtilitiesTest
     {
         [TestMethod]
-        public void CrossValidationUtilities_GetCrossValidationIndexSets_Handle_Remainder()
+        public void CrossValidationUtilities_GetKFoldCrossValidationIndexSets_Handle_Remainder()
         {
             var targets = new double[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3 };
             var sampler = new StratifiedIndexSampler<double>(seed: 242);
-            var actuals = CrossValidationUtilities.GetCrossValidationIndexSets(sampler, 
+            var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler, 
                 foldCount: 4, targets: targets);
 
             var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
@@ -37,11 +37,11 @@ namespace SharpLearning.CrossValidation.Test
         }
 
         [TestMethod]
-        public void CrossValidationUtilities_GetCrossValidationIndexSets()
+        public void CrossValidationUtilities_GetKFoldCrossValidationIndexSets()
         {
             var targets = new double[] { 1, 1, 1, 1 , 2, 2, 2, 2, 3, 3, 3, 3 };
             var sampler = new StratifiedIndexSampler<double>(seed: 242);
-            var actuals = CrossValidationUtilities.GetCrossValidationIndexSets(sampler,
+            var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler,
                 foldCount: 4, targets: targets);
 
             var expecteds = new List<(int[] trainingIndices, int[] validationIndices)>
@@ -63,12 +63,12 @@ namespace SharpLearning.CrossValidation.Test
         }
 
         [TestMethod]
-        public void CrossValidationUtilities_GetCrossValidationIndexSets_Indices()
+        public void CrossValidationUtilities_GetKFoldCrossValidationIndexSets_Indices()
         {
             var targets = new double[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3 };
             var indices = new int[] { 0, 1, 2, 3, 4, 5, 6 };
             var sampler = new StratifiedIndexSampler<double>(seed: 242);
-            var actuals = CrossValidationUtilities.GetCrossValidationIndexSets(sampler,
+            var actuals = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler,
                 foldCount: 2, targets: targets, indices: indices);
 
             TraceIndexSets(actuals);

--- a/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
+++ b/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
@@ -17,8 +17,8 @@ namespace SharpLearning.CrossValidation
         /// <param name="foldCount"></param>
         /// <param name="targets"></param>
         /// <returns></returns>
-        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetKFoldCrossValidationIndexSets(
-            IIndexSampler<double> sampler, int foldCount, double[] targets)
+        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetKFoldCrossValidationIndexSets<T>(
+            IIndexSampler<T> sampler, int foldCount, T[] targets)
         {
             var allIndices = Enumerable.Range(0, targets.Length).ToArray();
             return GetKFoldCrossValidationIndexSets(sampler, foldCount, targets, allIndices);
@@ -33,8 +33,8 @@ namespace SharpLearning.CrossValidation
         /// <param name="targets"></param>
         /// <param name="indices">indices to use for the cross validation sets</param>
         /// <returns></returns>
-        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetKFoldCrossValidationIndexSets(
-            IIndexSampler<double> sampler, int foldCount, double[] targets, int[] indices)
+        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetKFoldCrossValidationIndexSets<T>(
+            IIndexSampler<T> sampler, int foldCount, T[] targets, int[] indices)
         {
             var samplesPerFold = indices.Length / foldCount;
 

--- a/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
@@ -17,11 +17,11 @@ namespace SharpLearning.CrossValidation
         /// <param name="foldCount"></param>
         /// <param name="targets"></param>
         /// <returns></returns>
-        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
+        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetKFoldCrossValidationIndexSets(
             IIndexSampler<double> sampler, int foldCount, double[] targets)
         {
             var allIndices = Enumerable.Range(0, targets.Length).ToArray();
-            return GetCrossValidationIndexSets(sampler, foldCount, targets, allIndices);
+            return GetKFoldCrossValidationIndexSets(sampler, foldCount, targets, allIndices);
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace SharpLearning.CrossValidation
         /// <param name="targets"></param>
         /// <param name="indices">indices to use for the cross validation sets</param>
         /// <returns></returns>
-        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
+        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetKFoldCrossValidationIndexSets(
             IIndexSampler<double> sampler, int foldCount, double[] targets, int[] indices)
         {
             var samplesPerFold = indices.Length / foldCount;

--- a/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
@@ -43,12 +43,26 @@ namespace SharpLearning.CrossValidation
 
             for (int i = 0; i < foldCount; i++)
             {
-                var holdoutSample = sampler.Sample(targets, samplesPerFold, currentIndices);
-                // Sample only from remaining indices.
-                currentIndices = currentIndices.Except(holdoutSample).ToArray();
-                // Training sample is all indices except the current hold out sample.
-                var trainingSample = indices.Except(holdoutSample).ToArray();
-                crossValidationIndexSets.Add((trainingSample, holdoutSample));
+                int[] validationIndices;
+                if ((i == foldCount - 1) && targets.Length % foldCount != 0)
+                {
+                    // Last fold. Add remaining indices.
+                    // This is done to ensure that all indices are included,
+                    // even if the targets.Length % foldCount != 0.
+                    // Note, that this will make the ratio between training and validation
+                    // different for the last set compared to the others.
+                    validationIndices = currentIndices.ToArray();
+                }
+                else
+                {
+                    validationIndices = sampler.Sample(targets, samplesPerFold, currentIndices);
+                    // Sample only from remaining indices.
+                    currentIndices = currentIndices.Except(validationIndices).ToArray();
+                }
+
+                // Training sample is all indices except the current validation sample.
+                var trainingIndices = indices.Except(validationIndices).ToArray();
+                crossValidationIndexSets.Add((trainingIndices, validationIndices));
             }
 
             return crossValidationIndexSets;

--- a/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using SharpLearning.CrossValidation.Samplers;
+
+namespace SharpLearning.CrossValidation
+{
+    /// <summary>
+    /// Utilities for CrossValidation.
+    /// </summary>
+    public static class CrossValidationUtilities
+    {
+        /// <summary>
+        /// Returns a list of (trainingIndices, validationIndices) 
+        /// for use with k-fold cross-validation.
+        /// </summary>
+        /// <param name="sampler"></param>
+        /// <param name="foldCount"></param>
+        /// <param name="targets"></param>
+        /// <returns></returns>
+        public static List<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
+            IIndexSampler<double> sampler, int foldCount, double[] targets)
+        {
+            var allIndices = Enumerable.Range(0, targets.Length).ToArray();
+            return GetCrossValidationIndexSets(sampler, foldCount, targets, allIndices);
+        }
+
+        /// <summary>
+        /// Returns a list of (trainingIndices, validationIndices) 
+        /// for use with k-fold cross-validation.
+        /// </summary>
+        /// <param name="sampler"></param>
+        /// <param name="foldCount"></param>
+        /// <param name="targets"></param>
+        /// <param name="indices">indices to use for the cross validation sets</param>
+        /// <returns></returns>
+        public static List<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
+            IIndexSampler<double> sampler, int foldCount, double[] targets, int[] indices)
+        {
+            var samplesPerFold = targets.Length / foldCount;
+            var currentIndices = indices.ToArray();
+
+            var crossValidationIndexSets = new List<(int[] training, int[] validation)>();
+
+            for (int i = 0; i < foldCount; i++)
+            {
+                var holdoutSample = sampler.Sample(targets, samplesPerFold, currentIndices);
+                // Sample only from remaining indices.
+                currentIndices = currentIndices.Except(holdoutSample).ToArray();
+                // Training sample is all indices except the current hold out sample.
+                var trainingSample = indices.Except(holdoutSample).ToArray();
+                crossValidationIndexSets.Add((trainingSample, holdoutSample));
+            }
+
+            return crossValidationIndexSets;
+        }
+    }
+}

--- a/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
@@ -17,7 +17,7 @@ namespace SharpLearning.CrossValidation
         /// <param name="foldCount"></param>
         /// <param name="targets"></param>
         /// <returns></returns>
-        public static List<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
+        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
             IIndexSampler<double> sampler, int foldCount, double[] targets)
         {
             var allIndices = Enumerable.Range(0, targets.Length).ToArray();
@@ -33,18 +33,21 @@ namespace SharpLearning.CrossValidation
         /// <param name="targets"></param>
         /// <param name="indices">indices to use for the cross validation sets</param>
         /// <returns></returns>
-        public static List<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
+        public static IReadOnlyList<(int[] trainingIndices, int[] validationIndices)> GetCrossValidationIndexSets(
             IIndexSampler<double> sampler, int foldCount, double[] targets, int[] indices)
         {
-            var samplesPerFold = targets.Length / foldCount;
+            var samplesPerFold = indices.Length / foldCount;
+            var hasRemainder = indices.Length % foldCount != 0;
+
             var currentIndices = indices.ToArray();
-
             var crossValidationIndexSets = new List<(int[] training, int[] validation)>();
-
+            
             for (int i = 0; i < foldCount; i++)
             {
+                var lastFold = (i == foldCount - 1);
+
                 int[] validationIndices;
-                if ((i == foldCount - 1) && targets.Length % foldCount != 0)
+                if (lastFold && hasRemainder)
                 {
                     // Last fold. Add remaining indices.
                     // This is done to ensure that all indices are included,

--- a/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidationUtilities.cs
@@ -37,7 +37,6 @@ namespace SharpLearning.CrossValidation
             IIndexSampler<double> sampler, int foldCount, double[] targets, int[] indices)
         {
             var samplesPerFold = indices.Length / foldCount;
-            var hasRemainder = indices.Length % foldCount != 0;
 
             var currentIndices = indices.ToArray();
             var crossValidationIndexSets = new List<(int[] training, int[] validation)>();
@@ -45,9 +44,9 @@ namespace SharpLearning.CrossValidation
             for (int i = 0; i < foldCount; i++)
             {
                 var lastFold = (i == foldCount - 1);
-
                 int[] validationIndices;
-                if (lastFold && hasRemainder)
+
+                if (lastFold) // handle remainders.
                 {
                     // Last fold. Add remaining indices.
                     // This is done to ensure that all indices are included,

--- a/src/SharpLearning.CrossValidation/CrossValidators/CrossValidation.cs
+++ b/src/SharpLearning.CrossValidation/CrossValidators/CrossValidation.cs
@@ -78,7 +78,7 @@ namespace SharpLearning.CrossValidation.CrossValidators
             var cvPredictionIndiceMap = Enumerable.Range(0, crossValidatedPredictions.Length)
                 .ToDictionary(i => indices[i], i => i);
 
-            var crossValidationIndexSets = CrossValidationUtilities.GetCrossValidationIndexSets(
+            var crossValidationIndexSets = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(
                 m_indexedSampler, m_crossValidationFolds, targets, indices);
 
             var observation = new double[observations.ColumnCount];

--- a/src/SharpLearning.CrossValidation/SharpLearning.CrossValidation.csproj
+++ b/src/SharpLearning.CrossValidation/SharpLearning.CrossValidation.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\SharpLearning.Common.Interfaces\SharpLearning.Common.Interfaces.csproj" />
     <ProjectReference Include="..\SharpLearning.Containers\SharpLearning.Containers.csproj" />
     <ProjectReference Include="..\SharpLearning.InputOutput\SharpLearning.InputOutput.csproj" />


### PR DESCRIPTION
Extract the internal `GetKFoldCrossValidationIndexSets` method form the `CrossValidation<T>` class. 
This enables calculation of KFold CrossValidation IndexSets for use outside the `CrossValidation<T>` it self.

Usage: 

```csharp
// Targets to create KFold Index Sets from.
var targets = new double[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3 };
// Sampler to control the sampling of the sets. In this case Stratified.
var sampler = new StratifiedIndexSampler<double>(seed: 242);

var indexSets = CrossValidationUtilities.GetKFoldCrossValidationIndexSets(sampler,
    foldCount: 4, targets: targets);

foreach (var (trainingIndices, validationIndices) in indexSets)
{
    // Do model training and accumulate predictions,
    // to form a fully k-fold cross validated prediction array.
}
```

Note, that in the case of remainders from `samplesPerFold = targets.Length / foldCount`, the last validationIndices will contain the remaining values (making it larger compared to the others), and the last trainingIndices will exclude these (making it smaller than the others).