### PR TITLE
0.31.6.0: Adds implicit and explicit conversions from double[][] to F64Matrix

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.31.5.0</Version>
-    <AssemblyVersion>0.31.5.0</AssemblyVersion>
-    <FileVersion>0.31.5.0</FileVersion>
+	  <Version>0.31.6.0</Version>
+    <AssemblyVersion>0.31.6.0</AssemblyVersion>
+    <FileVersion>0.31.6.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Containers.Test/Matrices/F64MatrixTest.cs
+++ b/src/SharpLearning.Containers.Test/Matrices/F64MatrixTest.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpLearning.Containers.Matrices;
+using System;
 
 namespace SharpLearning.Containers.Test.Matrices
 {
@@ -101,7 +102,7 @@ namespace SharpLearning.Containers.Test.Matrices
         {
             var sut = CreateFeatures();
             var actual = new F64Matrix(2, 3);
-            sut.Rows(new int [] { 0, 2}, actual);
+            sut.Rows(new int[] { 0, 2 }, actual);
             var expected = GetExpectedRowSubMatrix();
 
             Assert.IsTrue(expected.Equals(actual));
@@ -126,6 +127,19 @@ namespace SharpLearning.Containers.Test.Matrices
             var expected = GetExpectedColSubMatrix();
 
             Assert.IsTrue(expected.Equals(actual));
+        }
+
+        [TestMethod]
+        public void F64Matrix_Implicit_Conversion()
+        {
+            Func<F64Matrix, F64Matrix> converter = m => m;
+
+            var actual = converter(new double[][] { new double[] { 0, 1 }, new double[] { 2, 3 } });
+
+           Assert.AreEqual(0, actual.At(0,0));
+           Assert.AreEqual(1, actual.At(0,1));
+           Assert.AreEqual(2, actual.At(1,0));
+           Assert.AreEqual(3, actual.At(1,1));
         }
 
         double[] GetExpectedColumn()

--- a/src/SharpLearning.Containers/Extensions/ArrayExtensions.cs
+++ b/src/SharpLearning.Containers/Extensions/ArrayExtensions.cs
@@ -195,10 +195,10 @@ namespace SharpLearning.Containers.Extensions
         /// <typeparam name="T"></typeparam>
         /// <param name="source"></param>
         /// <param name="interval"></param>
-        /// <param name="distination"></param>
-        public static void CopyTo<T>(this T[] source, Interval1D interval, T[] distination)
+        /// <param name="destination"></param>
+        public static void CopyTo<T>(this T[] source, Interval1D interval, T[] destination)
         {
-            Array.Copy(source, interval.FromInclusive, distination, interval.FromInclusive, interval.Length);
+            Array.Copy(source, interval.FromInclusive, destination, interval.FromInclusive, interval.Length);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace SharpLearning.Containers.Extensions
         /// <param name="source"></param>
         /// <param name="interval"></param>
         /// <param name="destination"></param>
-        public static void IndexedCopy(this int[] indices, F64MatrixColumnView source, 
+        public static void IndexedCopy(this int[] indices, F64MatrixColumnView source,
             Interval1D interval, double[] destination)
         {
             for (int i = interval.FromInclusive; i < interval.ToExclusive; i++)
@@ -354,8 +354,8 @@ namespace SharpLearning.Containers.Extensions
             var index = percentile * (values.Length - 1.0);
             var i = (int)index;
             var diff = index - i;
-            
-            if(diff != 0.0)
+
+            if (diff != 0.0)
             {
                 var j = i + 1;
                 var v1 = array[i];
@@ -363,11 +363,21 @@ namespace SharpLearning.Containers.Extensions
 
                 var v2 = array[j];
                 var w2 = index - i;
-                
+
                 return (v1 * w1 + v2 * w2) / (w1 + w2);
             }
 
             return array[i];
+        }
+
+        /// <summary>
+        /// Converts an array of arrays to an F64Matrix
+        /// </summary>
+        /// <param name="m"></param>
+        /// <returns></returns>
+        public static F64Matrix ToF64Matrix(this double[][] m)
+        {
+            return ToF64Matrix(m.ToList());
         }
 
         /// <summary>
@@ -456,7 +466,7 @@ namespace SharpLearning.Containers.Extensions
         {
             if (data.Length < sampleSize)
             {
-                throw new ArgumentException("SampleSize " + sampleSize + 
+                throw new ArgumentException("SampleSize " + sampleSize +
                     " is larger than data size " + data.Length);
             }
 
@@ -467,7 +477,7 @@ namespace SharpLearning.Containers.Extensions
             {
                 if (kvp.Value == 0)
                 {
-                    throw new ArgumentException("Sample size is too small for value: " + 
+                    throw new ArgumentException("Sample size is too small for value: " +
                         kvp.Key + " to be included.");
                 }
             }
@@ -477,12 +487,12 @@ namespace SharpLearning.Containers.Extensions
             indices.Shuffle(random);
 
             var currentSampleCount = requiredSamples.ToDictionary(k => k.Key, k => 0);
-            
+
             // might be slightly different than the specified depending on data distribution
             var actualSampleSize = requiredSamples.Select(s => s.Value).Sum();
-            
+
             // if actual sample size is different from specified add/subtract duff from largest class
-            if(actualSampleSize != sampleSize)
+            if (actualSampleSize != sampleSize)
             {
                 var diff = sampleSize - actualSampleSize;
                 var largestClassKey = requiredSamples.OrderByDescending(s => s.Value).First().Key;
@@ -491,12 +501,12 @@ namespace SharpLearning.Containers.Extensions
 
             var sampleIndices = new int[sampleSize];
             var sampleIndex = 0;
-                        
+
             for (int i = 0; i < data.Length; i++)
             {
                 var index = indices[i];
                 var value = data[index];
-                if(currentSampleCount[value] != requiredSamples[value])
+                if (currentSampleCount[value] != requiredSamples[value])
                 {
                     sampleIndices[sampleIndex++] = index;
                     currentSampleCount[value]++;
@@ -531,15 +541,15 @@ namespace SharpLearning.Containers.Extensions
         /// <returns></returns>
         public static int[] StratifiedIndexSampling<T>(this T[] data, int sampleSize, int[] dataIndices, Random random)
         {
-            if (dataIndices.Length < sampleSize) 
+            if (dataIndices.Length < sampleSize)
             {
-                throw new ArgumentException("SampleSize " + sampleSize + 
+                throw new ArgumentException("SampleSize " + sampleSize +
                     " is larger than dataIndices size " + dataIndices.Length);
             }
 
-            if (data.Length < dataIndices.Length) 
+            if (data.Length < dataIndices.Length)
             {
-                throw new ArgumentException("dataIndices " + dataIndices.Length + 
+                throw new ArgumentException("dataIndices " + dataIndices.Length +
                     " is larger than data size " + data.Length);
             }
 
@@ -550,7 +560,7 @@ namespace SharpLearning.Containers.Extensions
             {
                 if (kvp.Value == 0)
                 {
-                    throw new ArgumentException("Sample size is too small for value: " + 
+                    throw new ArgumentException("Sample size is too small for value: " +
                         kvp.Key + " to be included.");
                 }
             }
@@ -558,7 +568,7 @@ namespace SharpLearning.Containers.Extensions
             var currentSampleCount = requiredSamples.ToDictionary(k => k.Key, k => 0);
             // might be slightly different than the specified depending on data distribution
             var actualSampleSize = requiredSamples.Select(s => s.Value).Sum();
-            
+
             // if actual sample size is different from specified add/subtract difference from largest class
             if (actualSampleSize != sampleSize)
             {
@@ -584,7 +594,7 @@ namespace SharpLearning.Containers.Extensions
                     currentSampleCount[value]++;
                 }
 
-                if(sampleIndex == sampleSize)
+                if (sampleIndex == sampleSize)
                 {
                     break;
                 }

--- a/src/SharpLearning.Containers/Matrices/F64Matrix.cs
+++ b/src/SharpLearning.Containers/Matrices/F64Matrix.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Linq;
 using SharpLearning.Containers.Views;
+using SharpLearning.Containers.Extensions;
 
 namespace SharpLearning.Containers.Matrices
 {
     /// <summary>
     /// Matrix of doubles
     /// </summary>
+    /// <remarks>Can be implicitly converted from double[][]</remarks>
     public sealed unsafe class F64Matrix : IMatrix<double>, IEquatable<F64Matrix>
     {
         double[] m_featureArray;
@@ -301,5 +303,7 @@ namespace SharpLearning.Containers.Matrices
                 return hash;
             }
         }
+
+        public static implicit operator F64Matrix(double[][] b) => b.ToF64Matrix();
     }
 }

--- a/src/SharpLearning.Neural.Test/Learners/ClassificationNeuralNetLearnerTest.cs
+++ b/src/SharpLearning.Neural.Test/Learners/ClassificationNeuralNetLearnerTest.cs
@@ -20,7 +20,34 @@ namespace SharpLearning.Neural.Test.Learners
             var numberOfClasses = 5;
 
             var random = new Random(32);
-            var (observations, targets) = CreateData(numberOfObservations, 
+            var (observations, targets) = CreateData(numberOfObservations,
+                numberOfFeatures, numberOfClasses, random);
+
+            var net = new NeuralNet();
+            net.Add(new InputLayer(numberOfFeatures));
+            net.Add(new DenseLayer(10));
+            net.Add(new SvmLayer(numberOfClasses));
+
+            var sut = new ClassificationNeuralNetLearner(net, new AccuracyLoss());
+            var model = sut.Learn(observations, targets);
+
+            var predictions = model.Predict(observations);
+
+            var evaluator = new TotalErrorClassificationMetric<double>();
+            var actual = evaluator.Error(targets, predictions);
+
+            Assert.AreEqual(0.762, actual);
+        }
+
+        [TestMethod]
+        public void ClassificationNeuralNetLearner_Learn_Array()
+        {
+            var numberOfObservations = 500;
+            var numberOfFeatures = 5;
+            var numberOfClasses = 5;
+
+            var random = new Random(32);
+            var (observations, targets) = CreateArrayData(numberOfObservations,
                 numberOfFeatures, numberOfClasses, random);
 
             var net = new NeuralNet();
@@ -48,10 +75,10 @@ namespace SharpLearning.Neural.Test.Learners
 
             var random = new Random(32);
 
-            var (observations, targets) = CreateData(numberOfObservations, 
+            var (observations, targets) = CreateData(numberOfObservations,
                 numberOfFeatures, numberOfClasses, random);
 
-            var (validationObservations, validationTargets) = CreateData(numberOfObservations, 
+            var (validationObservations, validationTargets) = CreateData(numberOfObservations,
                 numberOfFeatures, numberOfClasses, random);
 
             var net = new NeuralNet();
@@ -92,5 +119,15 @@ namespace SharpLearning.Neural.Test.Learners
 
             return (observations, targets);
         }
+
+        (double[][] observations, double[] targets) CreateArrayData(
+            int numberOfObservations, int numberOfFeatures, int numberOfClasses, Random random)
+        {
+            var observations = Enumerable.Range(0, numberOfObservations).Select(i => Enumerable.Range(0, numberOfFeatures).Select(ii => random.NextDouble()).ToArray()).ToArray();
+            var targets = Enumerable.Range(0, numberOfObservations).Select(i => (double)random.Next(0, numberOfClasses)).ToArray();
+
+            return (observations, targets);
+        }
+
     }
 }

--- a/src/SharpLearning.Neural.Test/Learners/ClassificationNeuralNetLearnerTest.cs
+++ b/src/SharpLearning.Neural.Test/Learners/ClassificationNeuralNetLearnerTest.cs
@@ -123,11 +123,12 @@ namespace SharpLearning.Neural.Test.Learners
         (double[][] observations, double[] targets) CreateArrayData(
             int numberOfObservations, int numberOfFeatures, int numberOfClasses, Random random)
         {
-            var observations = Enumerable.Range(0, numberOfObservations).Select(i => Enumerable.Range(0, numberOfFeatures).Select(ii => random.NextDouble()).ToArray()).ToArray();
-            var targets = Enumerable.Range(0, numberOfObservations).Select(i => (double)random.Next(0, numberOfClasses)).ToArray();
+            var observations = Enumerable.Range(0, numberOfObservations).Select(i => Enumerable.Range(0, numberOfFeatures)
+                .Select(ii => random.NextDouble()).ToArray()).ToArray();
+            var targets = Enumerable.Range(0, numberOfObservations)
+                .Select(i => (double)random.Next(0, numberOfClasses)).ToArray();
 
             return (observations, targets);
         }
-
     }
 }


### PR DESCRIPTION
This is a simple way to address the need to expose an API surface that accepts double[][] rather than an F64Matrix. Instead of changing all interfaces and implementations, I have made double[][] implicitly convertible to F64Matrix. This can be considered a convenience and a temporary workaround for [#20](https://github.com/mdabros/SharpLearning/issues/20) and [#115 ](https://github.com/mdabros/SharpLearning/issues/115).