### PR TITLE
0.31.7.0: Refactor BaysianOptimizer and add parallel computation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.31.6.0</Version>
-    <AssemblyVersion>0.31.6.0</AssemblyVersion>
-    <FileVersion>0.31.6.0</FileVersion>
+	  <Version>0.31.7.0</Version>
+    <AssemblyVersion>0.31.7.0</AssemblyVersion>
+    <FileVersion>0.31.7.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
@@ -8,27 +10,33 @@ namespace SharpLearning.Optimization.Test
     public class BayesianOptimizerTest
     {
         [TestMethod]
-        public void BayesianOptimizer_OptimizeBest()
+        [DataRow(false)]
+        [DataRow(true)]
+        public void BayesianOptimizer_OptimizeBest_SingleParameter(bool runParallel)
         {
             var parameters = new MinMaxParameterSpec[]
             {
-                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
-                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
-                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
-            var sut = new BayesianOptimizer(parameters, 100, 5, 1, seed: 42, runParallel: false);
-            var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(-0.76070603822760785, actual.Error, Delta);
-            Assert.AreEqual(3, actual.ParameterSet.Length);
+            var sut = new BayesianOptimizer(parameters,
+                iterations: 80,
+                randomStartingPointCount: 20,
+                functionEvaluationsPerIterationCount: 1,
+                randomSearchPointCount: 1000,
+                seed: 42,
+                runParallel: runParallel);
 
-            Assert.AreEqual(1.6078245041928358, actual.ParameterSet[0], Delta);
-            Assert.AreEqual(-8.9735394990879769, actual.ParameterSet[1], Delta);
-            Assert.AreEqual(-0.18217921731163855, actual.ParameterSet[2], Delta);
+            var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
+
+            Assert.AreEqual(126.50056735005998, actual.Error, Delta);
+            Assert.AreEqual(38.359608938153649, actual.ParameterSet.Single(), Delta);
         }
 
         [TestMethod]
-        public void BayesianOptimizer_OptimizeBestInParallel()
+        [DataRow(false)]
+        [DataRow(true)]
+        public void BayesianOptimizer_OptimizeBest_MultipleParameters(bool runParallel)
         {
             var parameters = new MinMaxParameterSpec[]
             {
@@ -36,7 +44,15 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
-            var sut = new BayesianOptimizer(parameters, 100, 5, 1, seed: 42, runParallel: true);
+
+            var sut = new BayesianOptimizer(parameters,
+                iterations: 100,
+                randomStartingPointCount: 5,
+                functionEvaluationsPerIterationCount: 1,
+                randomSearchPointCount: 1000,
+                seed: 42,
+                runParallel: runParallel);
+
             var actual = sut.OptimizeBest(Minimize);
 
             Assert.AreEqual(-0.76070603822760785, actual.Error, Delta);
@@ -54,7 +70,17 @@ namespace SharpLearning.Optimization.Test
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
-            var sut = new BayesianOptimizer(parameters, 120, 5, 1, seed: 42, runParallel: false);
+
+            var sut = new BayesianOptimizer(parameters,
+                iterations: 120,
+                randomStartingPointCount: 5,
+                functionEvaluationsPerIterationCount: 1,
+                randomSearchPointCount: 1000,
+                seed: 42,
+                runParallel: false); // Note, since the returned results are not ordered on error, 
+                                     // running with parallel computations will not return reproducible order of results,
+                                     // so runParallel must be false for this test.
+
             var results = sut.Optimize(MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
@@ -65,12 +91,147 @@ namespace SharpLearning.Optimization.Test
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
-            Assert.AreEqual(expected.First().ParameterSet.First(),
-                actual.First().ParameterSet.First(), Delta);
+            Assert.AreEqual(expected.First().ParameterSet.First(), actual.First().ParameterSet.First(), Delta);
 
             Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
-            Assert.AreEqual(expected.Last().ParameterSet.First(),
-                actual.Last().ParameterSet.First(), Delta);
+            Assert.AreEqual(expected.Last().ParameterSet.First(), actual.Last().ParameterSet.First(), Delta);
+        }
+
+        [TestMethod]
+        public void BayesianOptimizer_OptimizeBest_MultipleParameters_Open_Loop()
+        {
+            var emptyResults = new List<OptimizerResult>();
+
+            OptimizerResult actual = RunOpenLoopOptimizationTest(emptyResults);
+
+            Assert.AreEqual(-0.72886252184027234, actual.Error, Delta);
+            Assert.AreEqual(actual.ParameterSet.Length, 3);
+
+            Assert.AreEqual(2.0474983901006638, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(-9.8598778060916246, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.10546011389487475, actual.ParameterSet[2], Delta);
+        }
+
+        [TestMethod]
+        public void BayesianOptimizer_OptimizeBest_MultipleParameters_Open_Loop_Using_PreviousResults()
+        {
+            var previousResults = new List<OptimizerResult>()
+            {
+                new OptimizerResult(new[] {-6.83357586936726,6.0834837966056,-0.0766206300242906}, -0.476143174040315),
+                new OptimizerResult(new[] {-7.29391428515963,6.0834837966056,1.01057317620636}, -0.41300737879641),
+                new OptimizerResult(new[] {-7.29391428515963,6.0834837966056,1.01057317620636}, -0.41300737879641),
+                new OptimizerResult(new[] {-8.05557010604794,-5.14662256238359,0.0363854738121798}, -0.397724266113204),
+                new OptimizerResult(new[] {-8.06241082868651,5.88012208038947,-1.5210571566229}, -0.356975377788698),
+                new OptimizerResult(new[] {4.42408777513732,0.472018332440413,1.7076749781648}, -0.315360461074171),
+                new OptimizerResult(new[] {-8.14483470197061,7.54724840519356,0.0363854738121798}, -0.279108605472165),
+                new OptimizerResult(new[] {-6.64746686660101,6.7109944004151,-0.214493549528761}, -0.266917186594653),
+                new OptimizerResult(new[] {5.34224593795009,-6.45170816986435,-2.1147669628797}, -0.255769932489526),
+                new OptimizerResult(new[] {-7.84876385603508,6.28409400409278,3.1447921661403}, -0.241263236969342),
+                new OptimizerResult(new[] {-7.84876385603508,4.96554990995934,-0.0766206300242906}, -0.232637166385485),
+                new OptimizerResult(new[] {-8.14041409554911,7.16927772256047,1.75166608381628}, -0.220476103560048),
+                new OptimizerResult(new[] {-7.84876385603508,6.0834837966056,-3.60210045874217}, -0.212970686239402),
+                new OptimizerResult(new[] {-7.29391428515963,5.22505613752876,1.01057317620636}, -0.206689239504653),
+                new OptimizerResult(new[] {-9.20479206331297,6.0834837966056,-0.0766206300242906}, -0.198657722521128),
+                new OptimizerResult(new[] {-8.25145286426481,5.27274844947865,-1.82163462593296}, -0.17367847378187),
+                new OptimizerResult(new[] {-7.84876385603508,6.0834837966056,5.3824106023565}, -0.153564625328103),
+                new OptimizerResult(new[] {-1.37364300497511,-1.35665034472786,-0.585322245296707}, -0.131453543138338),
+                new OptimizerResult(new[] {-7.84876385603508,7.74187722138216,-0.0766206300242906}, -0.103906821017427),
+                new OptimizerResult(new[] {9.20868899636375,-9.38389458664874,1.51842798642741}, -0.0850657757130275),
+                new OptimizerResult(new[] {-7.72406242681856,5.70825177044992,9.95585092341334}, -0.0759553721161318),
+                new OptimizerResult(new[] {1.65093947744506,-4.37866264692445,-4.29402069854272}, -0.0616761163702651),
+                new OptimizerResult(new[] {-9.37414173938993,6.28409400409278,0.0363854738121798}, -0.0488375857853505),
+                new OptimizerResult(new[] {3.38691201684387,5.42095644186295,-5.71318443664964}, -0.0235423806080941),
+                new OptimizerResult(new[] {-6.48224856540665,-7.13935053774125,7.05507751417117}, -0.0160884883078408),
+                new OptimizerResult(new[] {-9.68539061941457,7.96346846873102,-0.990608674935348}, -0.0141441279734299),
+                new OptimizerResult(new[] {-9.41382774124566,5.12580713030221,0.630654976996897}, -0.00269773409680873),
+                new OptimizerResult(new[] {6.7694738305963,1.56629731485913,-2.12145430600338}, 0.000673595210828553),
+                new OptimizerResult(new[] {-0.0282478006688169,2.87566112022645,-4.84997700660023}, 0.00465834522866944),
+                new OptimizerResult(new[] {3.50054986472267,8.01269467827524,7.36471213277649}, 0.00663762309484885),
+                new OptimizerResult(new[] {3.05129390817662,-6.16640157819092,7.49125691013935}, 0.0105475373675896),
+            };
+
+            OptimizerResult actual = RunOpenLoopOptimizationTest(previousResults);
+
+            Assert.AreEqual(-0.8720142225794828, actual.Error, Delta);
+            Assert.AreEqual(actual.ParameterSet.Length, 3);
+
+            Assert.AreEqual(-7.8218983383019918, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(-6.0818001516544262, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.12301634537196549, actual.ParameterSet[2], Delta);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void BayesianOptimizer_ArgumentCheck_ParameterRanges()
+        {
+            var sut = new BayesianOptimizer(null, 20);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void BayesianOptimizer_ArgumentCheck_Iterations()
+        {
+            var sut = new BayesianOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void BayesianOptimizer_ArgumentCheck_RandomStartingPointCount()
+        {
+            var sut = new BayesianOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void BayesianOptimizer_ArgumentCheck_FunctionEvaluationsPerIterationCount()
+        {
+            var sut = new BayesianOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 20, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void BayesianOptimizer_ArgumentCheck_RandomSearchPointCount()
+        {
+            var sut = new BayesianOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
+                10, 20, 30, 0);
+        }
+
+        OptimizerResult RunOpenLoopOptimizationTest(List<OptimizerResult> results)
+        {
+            var parameters = new MinMaxParameterSpec[]
+            {
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+                new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
+            };
+
+            var iterations = 80;
+            var randomStartingPointsCount = 20;
+            var functionEvaluationsPerIterationCount = 1;
+
+            var sut = new BayesianOptimizer(parameters,
+                iterations: iterations,
+                randomStartingPointCount: randomStartingPointsCount,
+                functionEvaluationsPerIterationCount: functionEvaluationsPerIterationCount,
+                randomSearchPointCount: 1000,
+                seed: 42);
+
+            // Using BayesianOptimizer in an open loop.
+            var initialParameterSets = sut.ProposeParameterSets(randomStartingPointsCount, results);
+            var initializationResults = sut.RunParameterSets(Minimize, initialParameterSets);
+            results.AddRange(initializationResults);
+
+            for (int i = 0; i < iterations; i++)
+            {
+                var parameterSets = sut.ProposeParameterSets(functionEvaluationsPerIterationCount, results);
+                var iterationResults = sut.RunParameterSets(Minimize, parameterSets);
+                results.AddRange(iterationResults);
+            }
+
+            return results.Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error).First();
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static SharpLearning.Optimization.Test.ObjectiveUtilities;
 
@@ -8,10 +7,6 @@ namespace SharpLearning.Optimization.Test
     [TestClass]
     public class BayesianOptimizerTest
     {
-
-        private const int Seed = 42;
-        private static Random Random = new Random(Seed);
-
         [TestMethod]
         public void BayesianOptimizer_OptimizeBest()
         {
@@ -21,15 +16,15 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
-            var sut = new BayesianOptimizer(parameters, 100, 5, 1, maxDegreeOfParallelism: 1);
+            var sut = new BayesianOptimizer(parameters, 100, 5, 1, seed: 42, runParallel: false);
             var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(-0.74765422244251278, actual.Error, 0.0001);
+            Assert.AreEqual(-0.76070603822760785, actual.Error, Delta);
             Assert.AreEqual(3, actual.ParameterSet.Length);
 
-            Assert.AreEqual(-5.00656832708352, actual.ParameterSet[0], Delta);
-            Assert.AreEqual(-9.67008227467075, actual.ParameterSet[1], Delta);
-            Assert.AreEqual(-0.241737044528936, actual.ParameterSet[2], Delta);
+            Assert.AreEqual(1.6078245041928358, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(-8.9735394990879769, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.18217921731163855, actual.ParameterSet[2], Delta);
         }
 
         [TestMethod]
@@ -41,16 +36,15 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
-            //high variance without fixed seed
-            var sut = new BayesianOptimizer(parameters, 100, 5, 2, seed: Seed);
+            var sut = new BayesianOptimizer(parameters, 100, 5, 1, seed: 42, runParallel: true);
             var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(-0.736123479387088, actual.Error, Delta);
+            Assert.AreEqual(-0.76070603822760785, actual.Error, Delta);
             Assert.AreEqual(3, actual.ParameterSet.Length);
 
-            Assert.AreEqual(-4.37019084318084, actual.ParameterSet[0], Delta);
-            Assert.AreEqual(-3.05224638108734, actual.ParameterSet[1], Delta);
-            Assert.AreEqual(0.274598500819224, actual.ParameterSet[2], Delta);
+            Assert.AreEqual(1.6078245041928358, actual.ParameterSet[0], Delta);
+            Assert.AreEqual(-8.9735394990879769, actual.ParameterSet[1], Delta);
+            Assert.AreEqual(-0.18217921731163855, actual.ParameterSet[2], Delta);
         }
 
         [TestMethod]
@@ -60,15 +54,15 @@ namespace SharpLearning.Optimization.Test
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
-            var sut = new BayesianOptimizer(parameters, 120, 5, 1, maxDegreeOfParallelism: 1);
+            var sut = new BayesianOptimizer(parameters, 120, 5, 1, seed: 42, runParallel: false);
             var results = sut.Optimize(MinimizeWeightFromHeight);
-            var actual = new OptimizerResult[] { results.First(), results.Last() }.OrderByDescending(o => o.Error);
+            var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]
-                {
-                    new OptimizerResult(new double[] { 90.513222660177 }, 114559.431919558),
-                    new OptimizerResult(new double[] { 24.2043804024367 }, 7601.00809036235)
-                };
+            {
+                new OptimizerResult(new double[] { 43.216748276360683 }, 1352.8306605984087),
+                new OptimizerResult(new double[] { 38.201425707992833 }, 119.1316225267316)
+            };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);
             Assert.AreEqual(expected.First().ParameterSet.First(),
@@ -78,22 +72,5 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(expected.Last().ParameterSet.First(),
                 actual.Last().ParameterSet.First(), Delta);
         }
-
-        [TestMethod]
-        public void BayesianOptimizer_OptimizeNonDeterministicInParallel()
-        {
-            var parameters = new MinMaxParameterSpec[]
-            {
-                new MinMaxParameterSpec(0, 1, Transform.Linear, ParameterType.Discrete)
-            };
-            var sut = new BayesianOptimizer(parameters, iterations: 240, randomStartingPointCount: 5, functionEvaluationsPerIteration: 5,
-                seed: Seed, maxDegreeOfParallelism: -1, allowMultipleEvaluations: true);
-            var results = sut.Optimize(p => MinimizeNonDeterministic(p, Random));
-            var actual = new OptimizerResult[] { results.First(), results.Last() }.OrderByDescending(o => o.Error);
-
-            Assert.AreEqual(1, actual.First().Error);
-            Assert.AreEqual(1, (int)actual.First().ParameterSet[0]);
-        }
-
     }
 }

--- a/src/SharpLearning.Optimization/BayesianOptimizer.cs
+++ b/src/SharpLearning.Optimization/BayesianOptimizer.cs
@@ -52,12 +52,19 @@ namespace SharpLearning.Optimization
         /// https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf
         /// </summary>
         /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
-        /// <param name="iterations">Number of iterations. Iteration * functionEvaluationsPerIteration = totalFunctionEvaluations</param>
-        /// <param name="randomStartingPointCount">Number of randomly created starting points to use for the initial model in the first iteration (default is 5)</param>
+        /// <param name="iterations">The number of iterations to perform.
+        /// Iteration * functionEvaluationsPerIteration = totalFunctionEvaluations</param>
+        /// <param name="randomStartingPointCount">Number of randomly parameter sets used 
+        /// for initialization (default is 20)</param>
         /// <param name="functionEvaluationsPerIterationCount">The number of function evaluations per iteration. 
         /// The parameter sets are included in order of most promising outcome (default is 1)</param>
-        /// <param name="seed">Seed for the random initialization</param>
-        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations. Default is -1 (unlimited)</param>
+        /// <param name="randomSearchPointCount">The number of random parameter sets
+        /// used when maximizing the expected improvement acquisition function (default is 1000)</param>
+        /// <param name="seed"></param>
+        /// <param name="runParallel">Use multi threading to speed up execution (default is false).
+        /// Note that the order of results returned the Optimize method will not be reproducible when running in parallel.
+        /// Results will be the same, only the order is not reproducible</param>
+        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is -1 (unlimited))</param>
         public BayesianOptimizer(IParameterSpec[] parameters,
             int iterations,
             int randomStartingPointCount = 5,

--- a/src/SharpLearning.Optimization/BayesianOptimizer.cs
+++ b/src/SharpLearning.Optimization/BayesianOptimizer.cs
@@ -71,7 +71,7 @@ namespace SharpLearning.Optimization
             int functionEvaluationsPerIterationCount = 1,
             int randomSearchPointCount = 1000,
             int seed = 42,
-            bool runParallel = true,
+            bool runParallel = false,
             int maxDegreeOfParallelism = -1)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));

--- a/src/SharpLearning.Optimization/BayesianOptimizer.cs
+++ b/src/SharpLearning.Optimization/BayesianOptimizer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using SharpLearning.Containers.Extensions;
@@ -28,16 +29,10 @@ namespace SharpLearning.Optimization
         readonly int m_iterations;
         readonly int m_randomStartingPointsCount;
         readonly int m_functionEvaluationsPerIterationCount;
-        private readonly bool m_runParallel;
-        private readonly ParallelOptions m_parallelOptions;
-        private readonly bool m_allowMultipleEvaluations;
+        readonly int m_maxDegreeOfParallelism;
+        readonly bool m_runParallel;
         readonly IParameterSampler m_sampler;
         readonly Random m_random;
-        readonly object m_locker;
-        const double m_tolerence = 0.00001;
-
-        readonly List<double[]> m_previousParameterSets;
-        readonly List<double> m_previousParameterSetScores;
 
         // Important to use extra trees learner to have split between features calculated as: 
         // m_random.NextDouble() * (max - min) + min; 
@@ -49,7 +44,6 @@ namespace SharpLearning.Optimization
 
         // Acquisition function to maximize
         readonly AcquisitionFunction m_acquisitionFunc;
-        private bool m_isFirst;
 
         /// <summary>
         /// Bayesian optimization (BO) for global black box optimization problems. BO learns a model based on the initial parameter sets and scores.
@@ -69,14 +63,13 @@ namespace SharpLearning.Optimization
         /// The parameter sets are included in order of most promising outcome (default is 1)</param>
         /// <param name="seed">Seed for the random initialization</param>
         /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations. Default is -1 (unlimited)</param>
-        /// <param name="allowMultipleEvaluations">Enables re-evaluation of duplicate parameter sets for non-deterministic functions</param>
         public BayesianOptimizer(IParameterSpec[] parameters,
             int iterations,
             int randomStartingPointCount = 5,
             int functionEvaluationsPerIteration = 1,
             int seed = 42,
-            int maxDegreeOfParallelism = -1,
-            bool allowMultipleEvaluations = false)
+            bool runParallel = true,
+            int maxDegreeOfParallelism = -1)
         {
             if (iterations <= 0) { throw new ArgumentException("maxIterations must be at least 1"); }
             if (randomStartingPointCount < 1) { throw new ArgumentException("numberOfParticles must be at least 1"); }
@@ -85,11 +78,10 @@ namespace SharpLearning.Optimization
             m_iterations = iterations;
             m_randomStartingPointsCount = randomStartingPointCount;
             m_functionEvaluationsPerIterationCount = functionEvaluationsPerIteration;
-            m_runParallel = maxDegreeOfParallelism != 1;
-            m_parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism };
-            m_allowMultipleEvaluations = allowMultipleEvaluations;
-            m_locker = new object();
 
+            m_runParallel = runParallel;
+            m_maxDegreeOfParallelism = maxDegreeOfParallelism;
+            
             m_random = new Random(seed);
 
             // Use member to seed the random uniform sampler.
@@ -104,92 +96,7 @@ namespace SharpLearning.Optimization
                 minimumInformationGain: 1e-6,
                 subSampleRatio: 1.0,
                 seed: m_random.Next(), // Use member to seed the random uniform sampler.
-                runParallel: m_runParallel);
-
-            // Optimizer for finding maximum expectation (most promising hyper parameters) from extra trees model.
-            m_maximizer = new RandomSearchOptimizer(m_parameters, iterations: 1000,
-                seed: m_random.Next(), // Use member to seed the random uniform sampler.
-                runParallel: maxDegreeOfParallelism > 1);
-
-            // Acquisition function to maximize.
-            m_acquisitionFunc = AcquisitionFunctions.ExpectedImprovement;
-        }
-
-
-        /// <summary>
-        /// Bayesian optimization (BO) for global black box optimization problems. BO learns a model based on the initial parameter sets and scores.
-        /// This model is used to sample new promising parameter candidates which are evaluated and added to the existing parameter sets.
-        /// This process iterates several times. The method is computational expensive so is most relevant for expensive problems, 
-        /// where each evaluation of the function to minimize takes a long time, like hyper parameter tuning a machine learning method.
-        /// But in that case it can usually reduce the number of iterations required to reach a good solution compared to less sophisticated methods.
-        /// Implementation loosely based on:
-        /// http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf
-        /// https://papers.nips.cc/paper/4522-practical-bayesian-optimization-of-machine-learning-algorithms.pdf
-        /// https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf
-        /// </summary>
-        /// <param name="parameters">A list of parameter specs, one for each optimization parameter</param>
-        /// <param name="iterations">Maximum number of iterations. MaxIteration * numberOfCandidatesEvaluatedPrIteration = totalFunctionEvaluations</param>
-        /// <param name="previousParameterSets">Parameter sets from previous run</param>
-        /// <param name="previousParameterSetScores">Scores from previous run corresponding to each parameter set</param>
-        /// <param name="functionEvaluationsPerIteration">How many candidate parameter set should by sampled from the model in each iteration. 
-        /// The parameter sets are included in order of most promising outcome (default is 1)</param>
-        /// <param name="seed">Seed for the random initialization</param>
-        /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations. Default is -1 (unlimited)</param>
-        /// <param name="allowMultipleEvaluations">Enables re-evaluation of duplicate parameter sets for non-deterministic functions</param>
-        public BayesianOptimizer(IParameterSpec[] parameters,
-            int iterations,
-            List<double[]> previousParameterSets,
-            List<double> previousParameterSetScores,
-            int functionEvaluationsPerIteration = 1,
-            int seed = 42,
-            int maxDegreeOfParallelism = -1,
-            bool allowMultipleEvaluations = false)
-        {
-            if (iterations <= 0) { throw new ArgumentNullException("iterations must be at least 1"); }
-            if (previousParameterSets.Count != previousParameterSetScores.Count)
-            {
-                throw new ArgumentException("previousParameterSets length: "
-                    + previousParameterSets.Count + " does not correspond with previousResults length: "
-                    + previousParameterSetScores.Count);
-            }
-
-            if (previousParameterSetScores.Count < 2 || previousParameterSets.Count < 2)
-            {
-                throw new ArgumentException("previousParameterSets length and previousResults length must be at least 2 and was: "
-                    + previousParameterSetScores.Count);
-            }
-
-            m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
-            m_previousParameterSets = previousParameterSets ?? throw new ArgumentNullException(nameof(previousParameterSets));
-            m_previousParameterSetScores = previousParameterSetScores ?? throw new ArgumentNullException(nameof(previousParameterSetScores));
-
-            m_iterations = iterations;
-            m_functionEvaluationsPerIterationCount = functionEvaluationsPerIteration;
-            m_parallelOptions = new ParallelOptions { MaxDegreeOfParallelism = maxDegreeOfParallelism };
-            m_runParallel = maxDegreeOfParallelism != 1;
-            m_allowMultipleEvaluations = allowMultipleEvaluations;
-            m_locker = new object();
-
-            m_random = new Random(seed);
-
-            // Use member to seed the random uniform sampler.
-            m_sampler = new RandomUniform(m_random.Next());
-
-            // Hyper parameters for regression extra trees learner. These are based on the values suggested in http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf.
-            // However, according to the author Frank Hutter, the hyper parameters for the forest model should not matter that much.
-            m_learner = new RegressionExtremelyRandomizedTreesLearner(trees: 30,
-                minimumSplitSize: 10,
-                maximumTreeDepth: 2000,
-                featuresPrSplit: parameters.Length,
-                minimumInformationGain: 1e-6,
-                subSampleRatio: 1.0,
-                seed: m_random.Next(), // Use member to seed the random uniform sampler.
-                runParallel: m_runParallel);
-
-            // Optimizer for finding maximum expectation (most promising hyper parameters) from extra trees model.
-            m_maximizer = new RandomSearchOptimizer(m_parameters, iterations: 1000,
-                seed: m_random.Next(), // Use member to seed the random uniform sampler.
-                runParallel: m_runParallel);
+                runParallel: false);
 
             // Acquisition function to maximize.
             m_acquisitionFunc = AcquisitionFunctions.ExpectedImprovement;
@@ -229,106 +136,6 @@ namespace SharpLearning.Optimization
             return results.ToArray();
         }
 
-
-        ///// <summary>
-        ///// Optimization using Sequential Model-based optimization.
-        ///// Returns all results, chronologically ordered. 
-        ///// </summary>
-        ///// <param name="functionToMinimize"></param>
-        ///// <returns></returns>
-        //public OptimizerResult[] Optimize(Func<double[], OptimizerResult> functionToMinimize)
-        //{
-        //    var parameterSets = new BlockingCollection<(double[] Parameters, double Error)>();
-        //    var usePreviousResults = m_previousParameterSetScores != null && m_previousParameterSets != null;
-
-        //    int iterations = 0;
-
-        //    if (usePreviousResults)
-        //    {
-        //        for (int i = 0; i < m_previousParameterSets.Count; i++)
-        //        {
-        //            var score = m_previousParameterSetScores[i];
-        //            if (!double.IsNaN(score))
-        //            {
-        //                parameterSets.Add((m_previousParameterSets[i], score));
-        //            }
-        //        }
-        //    }
-        //    else
-        //    {
-        //        // initialize random starting points for the first iteration
-        //        Parallel.For(0, m_randomStartingPointsCount, m_parallelOptions, i =>
-        //        {
-        //            var set = RandomSearchOptimizer.SampleParameterSet(m_parameters, m_sampler);
-        //            var score = functionToMinimize(set).Error;
-        //            iterations++;
-
-        //            if (!double.IsNaN(score))
-        //            {
-        //                parameterSets.Add((set, score));
-        //            }
-        //        });
-        //    }
-        //    for (int iteration = 0; iteration < m_iterations; iteration++)
-        //    {
-        //        // fit model			
-        //        var observations = parameterSets.Select(s => s.Parameters).ToList().ToF64Matrix();
-        //        var targets = parameterSets.Select(s => s.Error).ToArray();
-        //        var model = m_learner.Learn(observations, targets);
-
-        //        var bestScore = parameterSets.Min(m => m.Error);
-        //        var candidates = FindNextCandidates(model, bestScore);
-
-        //        m_isFirst = true;
-
-        //        Parallel.ForEach(candidates, m_parallelOptions, candidate =>
-        //        {
-        //            var parameterSet = candidate.ParameterSet;
-
-        //            // skip evaluation if parameters have not changed unless explicitly allowed
-        //            if (m_allowMultipleEvaluations || IsFirstEvaluation() || !Contains(parameterSets, parameterSet))
-        //            {
-
-        //                if (!m_allowMultipleEvaluations && Equals(GetBestParameterSet(parameterSets), parameterSet))
-        //                {
-        //                    // if the best parameter set is sampled again.
-        //                    // Add a new random parameter set.
-        //                    parameterSet = RandomSearchOptimizer
-        //                        .SampleParameterSet(m_parameters, m_sampler);
-        //                }
-
-        //                var result = functionToMinimize(parameterSet);
-        //                iterations++;
-
-        //                if (!double.IsNaN(result.Error))
-        //                {
-        //                    // add point to parameter set list for next iterations model
-        //                    parameterSets.Add((parameterSet, result.Error));
-        //                }
-
-        //            }
-        //        });
-
-        //    }
-
-        //    return parameterSets.Select(p => new OptimizerResult(p.Parameters, p.Error)).ToArray();
-        //}
-
-        bool IsFirstEvaluation()
-        {
-            lock (m_locker)
-            {
-                if (m_isFirst)
-                {
-                    m_isFirst = false;
-                    return true;
-                }
-
-            }
-
-            return m_isFirst;
-        }
-
         /// <summary>
         /// Runs a set of parameter sets and returns the results.
         /// </summary>
@@ -338,15 +145,29 @@ namespace SharpLearning.Optimization
         public List<OptimizerResult> RunParameterSets(Func<double[], OptimizerResult> functionToMinimize,
             double[][] parameterSets)
         {
-            var results = new List<OptimizerResult>();
-            foreach (var parameterSet in parameterSets)
+            var results = new ConcurrentBag<OptimizerResult>();
+            if (!m_runParallel)
             {
-                // Get the current parameters for the current point
-                var result = functionToMinimize(parameterSet);
-                results.Add(result);
+                foreach (var parameterSet in parameterSets)
+                {
+                    // Get the current parameters for the current point
+                    var result = functionToMinimize(parameterSet);
+                    results.Add(result);
+                }
+            }
+            else
+            {
+                var rangePartitioner = Partitioner.Create(parameterSets, true);
+                var options = new ParallelOptions { MaxDegreeOfParallelism = m_maxDegreeOfParallelism };
+                Parallel.ForEach(rangePartitioner, options, (param, loopState) =>
+                {
+                    // Get the current parameters for the current point
+                    var result = functionToMinimize(param);
+                    results.Add(result);
+                });
             }
 
-            return results;
+            return results.ToList();
         }
 
         /// <summary>
@@ -372,7 +193,11 @@ namespace SharpLearning.Optimization
                 return randomParameterSets;
             }
 
-            var validParameterSets = previousResults.Where(v => !double.IsNaN(v.Error));
+            // Filter away NaNs, and ensure result order is preserved, when fitting the model.
+            var validParameterSets = previousResults
+                .Where(v => !double.IsNaN(v.Error))
+                .OrderBy(v => v.Error); // TODO: This might still fail to provide same order if two different parameter sets yield the same error.
+            
             var model = FitModel(validParameterSets);
 
             return GenerateCandidateParameterSets(parameterSetCount, validParameterSets.ToList(), model);
@@ -396,12 +221,15 @@ namespace SharpLearning.Optimization
             // TODO: Handle maximization and minimization. Currently minimizes.
             var best = previousResults.Min(v => v.Error);
 
-            // Use maximizer for sampling potential new candidates.
+            // Sample new candidates.
             var results = FindNextCandidates(model, best);
 
             // Return the top candidate sets requested.
+            // Error is used to store ExpectedImprovement, so we want the maximum value
+            // not the minimum.
             var candidates = results
-                .Where(v => !double.IsNaN(v.Error)).OrderBy(r => r.Error)
+                .Where(v => !double.IsNaN(v.Error))
+                .OrderByDescending(r => r.Error) 
                 .Take(parameterSetCount)
                 .Select(p => p.ParameterSet).ToArray();
 
@@ -410,62 +238,27 @@ namespace SharpLearning.Optimization
 
         OptimizerResult[] FindNextCandidates(RegressionForestModel model, double bestScore)
         {
-            OptimizerResult minimize(double[] param)
+            // Additional set of random parameterSets to choose from during local search.
+            var results = new List<OptimizerResult>();
+            var m_randomSearchPointCount = 1000;
+            for (int i = 0; i < m_randomSearchPointCount; i++)
             {
-                // use the model to predict the expected performance, mean and variance, of the parameter set.
-                var p = model.PredictCertainty(param);
+                var parameterSet = RandomSearchOptimizer
+                    .SampleParameterSet(m_parameters, m_sampler);
 
-                return new OptimizerResult(param,
-                    // negative, since we want to "maximize" the acquisition function.
-                    -m_acquisitionFunc(bestScore, p.Prediction, p.Variance));
+                var expectedImprovement = ComputeExpectedImprovement(bestScore, parameterSet, model);
+                results.Add(new OptimizerResult(parameterSet, expectedImprovement));
             }
 
-            return m_maximizer.Optimize(minimize);
+            return results.ToArray();
         }
 
-        bool Equals(double[] p1, double[] p2)
+        double ComputeExpectedImprovement(double best, double[] parameterSet, RegressionForestModel model)
         {
-            if (p1 == null)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < p1.Length; i++)
-            {
-                if (!Equal(p1[i], p2[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        bool Contains(BlockingCollection<(double[] Parameters, double Error)> many, double[] single)
-        {
-            lock (m_locker)
-            {
-                return many.Any(m => Equals(m.Parameters, single));
-            }
-        }
-
-        bool Equal(double a, double b)
-        {
-            var diff = Math.Abs(a * m_tolerence);
-            if (Math.Abs(a - b) <= diff)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        double[] GetBestParameterSet(BlockingCollection<(double[] Parameters, double Error)> parameterSets)
-        {
-            lock (m_locker)
-            {
-                return parameterSets.FirstOrDefault(f => f.Error == parameterSets.Min(p => p.Error)).Parameters;
-            }
+            var prediction = model.PredictCertainty(parameterSet);
+            var mean = prediction.Prediction;
+            var variance = prediction.Variance;
+            return AcquisitionFunctions.ExpectedImprovement(best, mean, variance);
         }
     }
 }

--- a/src/SharpLearning.Optimization/SmacOptimizer.cs
+++ b/src/SharpLearning.Optimization/SmacOptimizer.cs
@@ -79,7 +79,6 @@ namespace SharpLearning.Optimization
             m_random = new Random(seed);
             // Use member to seed the random uniform sampler.
             m_sampler = new RandomUniform(m_random.Next());
-            m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             m_iterations = iterations;
             m_randomStartingPointsCount = randomStartingPointCount;
             m_functionEvaluationsPerIterationCount = functionEvaluationsPerIterationCount;


### PR DESCRIPTION
This pull request refactors the `BayesianOptimizer` implementation to be use the same principles as the `SMACOptimizer`. The two optimizers are both model based optimizers, and should therefore be very similar in implementation. The `BayesianOptimizer` can be viewed a basic implementation of model based optimization, which the `SMACOptimizer` builds a few tricks on top of.
A base class for model based optimizers seems to be the next logical step, but that will follow in a later pull request.

The refactoring enables use of the `BayesianOptimizer` in an "open loop" style just like the `SMACOptimizer`. See the unit tests for an example.

This pull request also adds the option of parallel computation to the `BayesianOptimizer`. This work was originally added in #119.

Note that when running in parallel, and using the `Optimize(Func<double[], OptimizerResult> functionToMinimize)` method, the order of the results will not be reproducible. The individuel results will remain the same, but the order of the results will vary between runs.

I recommend only using the parallel version if the provided `functionToMinimize` is running serial computation, and is slow to compute.