### PR TITLE
0.31.8.0: Ensure deterministic order of results from multithreaded optimizers

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-	  <Version>0.31.7.0</Version>
-    <AssemblyVersion>0.31.7.0</AssemblyVersion>
-    <FileVersion>0.31.7.0</FileVersion>
+	  <Version>0.31.8.0</Version>
+    <AssemblyVersion>0.31.8.0</AssemblyVersion>
+    <FileVersion>0.31.8.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Mads Dabros</Authors>
     <Copyright>Copyright © Mads Dabros 2014</Copyright>

--- a/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/BayesianOptimizerTest.cs
@@ -10,16 +10,18 @@ namespace SharpLearning.Optimization.Test
     public class BayesianOptimizerTest
     {
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
-        public void BayesianOptimizer_OptimizeBest_SingleParameter(bool runParallel)
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(-1)]
+        [DataRow(null)]
+        public void BayesianOptimizer_OptimizeBest_SingleParameter(int? maxDegreeOfParallelism)
         {
             var parameters = new MinMaxParameterSpec[]
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = CreateSut(runParallel, parameters);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
 
@@ -28,9 +30,11 @@ namespace SharpLearning.Optimization.Test
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
-        public void BayesianOptimizer_OptimizeBest_MultipleParameters(bool runParallel)
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(-1)]
+        [DataRow(null)]
+        public void BayesianOptimizer_OptimizeBest_MultipleParameters(int? maxDegreeOfParallelism)
         {
             var parameters = new MinMaxParameterSpec[]
             {
@@ -39,7 +43,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
 
-            var sut = CreateSut(runParallel, parameters);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var actual = sut.OptimizeBest(Minimize);
 
@@ -52,16 +56,18 @@ namespace SharpLearning.Optimization.Test
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
-        public void BayesianOptimizer_Optimize(bool runParallel)
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(-1)]
+        [DataRow(null)]
+        public void BayesianOptimizer_Optimize(int? maxDegreeOfParallelism)
         {
             var parameters = new MinMaxParameterSpec[]
             {
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = CreateSut(runParallel, parameters);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var results = sut.Optimize(MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
@@ -182,16 +188,15 @@ namespace SharpLearning.Optimization.Test
         }
 
         static BayesianOptimizer CreateSut(
-            bool runParallel,
-            //int? maybeMaxDegreeOfParallelism,
+            int? maybeMaxDegreeOfParallelism,
             MinMaxParameterSpec[] parameters)
         {
             const int DefaultMaxDegreeOfParallelism = -1;
 
-            //var maxDegreeOfParallelism = maybeMaxDegreeOfParallelism.HasValue ?
-            //    maybeMaxDegreeOfParallelism.Value : DefaultMaxDegreeOfParallelism;
+            var maxDegreeOfParallelism = maybeMaxDegreeOfParallelism.HasValue ?
+                maybeMaxDegreeOfParallelism.Value : DefaultMaxDegreeOfParallelism;
 
-            //var runParallel = maybeMaxDegreeOfParallelism.HasValue;
+            var runParallel = maybeMaxDegreeOfParallelism.HasValue;
 
             var sut = new BayesianOptimizer(parameters,
                 iterations: 30,
@@ -199,7 +204,8 @@ namespace SharpLearning.Optimization.Test
                 functionEvaluationsPerIterationCount: 5,
                 randomSearchPointCount: 1000,
                 seed: 42,
-                runParallel: runParallel);
+                runParallel: runParallel,
+                maxDegreeOfParallelism: maxDegreeOfParallelism);
 
             return sut;
         }

--- a/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
@@ -21,19 +21,16 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
 
-            var sut = maxDegreeOfParallelism.HasValue ? 
-                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10, 
-                    maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
-                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var actual = sut.OptimizeBest(Minimize);
 
-            Assert.AreEqual(actual.Error, -0.99999949547279676, Delta);
+            Assert.AreEqual(actual.Error, -0.99999960731425908, Delta);
             Assert.AreEqual(actual.ParameterSet.Length, 3);
 
-            Assert.AreEqual(actual.ParameterSet[0], -7.8547285710964134, Delta);
-            Assert.AreEqual(actual.ParameterSet[1], 6.2835515298977995, Delta);
-            Assert.AreEqual(actual.ParameterSet[2], -1.5851024386788885E-07, Delta);
+            Assert.AreEqual(actual.ParameterSet[0], -1.5711056814954487, Delta);
+            Assert.AreEqual(actual.ParameterSet[1], -6.283490634742785, Delta);
+            Assert.AreEqual(actual.ParameterSet[2], -2.9822323517533149E-07, Delta);
         }
 
         [TestMethod]
@@ -48,10 +45,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = maxDegreeOfParallelism.HasValue ? 
-                new GlobalizedBoundedNelderMeadOptimizer(parameters, 50, 1e-5, 10, 
-                    maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
-                new GlobalizedBoundedNelderMeadOptimizer(parameters, 50, 1e-5, 10);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var results = sut.Optimize(MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
@@ -69,6 +63,31 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), 
                 actual.Last().ParameterSet.First(), Delta);
+        }
+
+        static GlobalizedBoundedNelderMeadOptimizer CreateSut(
+            int? maybeMaxDegreeOfParallelism, 
+            MinMaxParameterSpec[] parameters)
+        {
+            const int DefaultMaxDegreeOfParallelism = -1;
+
+            var maxDegreeOfParallelism = maybeMaxDegreeOfParallelism.HasValue ?
+                maybeMaxDegreeOfParallelism.Value : DefaultMaxDegreeOfParallelism;
+
+            var sut = new GlobalizedBoundedNelderMeadOptimizer(parameters,
+                maxRestarts: 50,
+                noImprovementThreshold: 1e-5,
+                maxIterationsWithoutImprovement: 10,
+                maxIterationsPrRestart: 0,
+                maxFunctionEvaluations: 0,
+                alpha: 1,
+                gamma: 2,
+                rho: -0.5,
+                sigma: 0.5,
+                seed: 324,
+                maxDegreeOfParallelism: maxDegreeOfParallelism);
+
+            return sut;
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/GlobalizedBoundedNelderMeadOptimizerTest.cs
@@ -49,17 +49,17 @@ namespace SharpLearning.Optimization.Test
             };
 
             var sut = maxDegreeOfParallelism.HasValue ? 
-                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10, 
+                new GlobalizedBoundedNelderMeadOptimizer(parameters, 50, 1e-5, 10, 
                     maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
-                new GlobalizedBoundedNelderMeadOptimizer(parameters, 5, 1e-5, 10);
+                new GlobalizedBoundedNelderMeadOptimizer(parameters, 50, 1e-5, 10);
 
             var results = sut.Optimize(MinimizeWeightFromHeight);
             var actual = new OptimizerResult[] { results.First(), results.Last() };
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 37.71314535727786 }, 109.34381396310141),
-                new OptimizerResult(new double[] { 37.7131485180996 }, 109.34381396350526)
+                new OptimizerResult(new double[] { 37.71314634450421 }, 109.3438139631394),
+                new OptimizerResult(new double[] { 37.713142445047254 }, 109.34381396345546)
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);

--- a/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/GridSearchOptimizationTest.cs
@@ -39,7 +39,7 @@ namespace SharpLearning.Optimization.Test
         {
             var parameters = new GridParameterSpec[] 
             {
-                new GridParameterSpec(10.0, 37.5)
+                new GridParameterSpec(10.0, 20.0, 30.0, 35.0, 37.5, 40.0, 50.0, 60.0)
             };
 
             var sut = maxDegreeOfParallelism.HasValue ? 
@@ -50,8 +50,8 @@ namespace SharpLearning.Optimization.Test
 
             var expected = new OptimizerResult[] 
             { 
-              new OptimizerResult(new double[] { 37.5 }, 111.20889999999987),
-              new OptimizerResult(new double[] { 10 }, 31638.9579) 
+              new OptimizerResult(new double[] { 10 }, 31638.9579),
+              new OptimizerResult(new double[] { 60 }, 20500.6279) 
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);

--- a/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/ParticleSwarmOptimizerTest.cs
@@ -21,9 +21,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
 
-            var sut = maxDegreeOfParallelism.HasValue ? 
-                new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
-                new ParticleSwarmOptimizer(parameters, 100);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var actual = sut.OptimizeBest(Minimize);
 
@@ -47,9 +45,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = maxDegreeOfParallelism.HasValue ? 
-                new ParticleSwarmOptimizer(parameters, 100, maxDegreeOfParallelism: maxDegreeOfParallelism.Value) : 
-                new ParticleSwarmOptimizer(parameters, 100);
+            var sut = CreateSut(maxDegreeOfParallelism, parameters);
 
             var results = sut.Optimize(MinimizeWeightFromHeight);
 
@@ -68,6 +64,26 @@ namespace SharpLearning.Optimization.Test
             Assert.AreEqual(expected.Last().Error, actual.Last().Error, Delta);
             Assert.AreEqual(expected.Last().ParameterSet.First(), 
                 actual.Last().ParameterSet.First(), Delta);
+        }
+
+        static ParticleSwarmOptimizer CreateSut(
+            int? maybeMaxDegreeOfParallelism,
+            MinMaxParameterSpec[] parameters)
+        {
+            const int DefaultMaxDegreeOfParallelism = -1;
+
+            var maxDegreeOfParallelism = maybeMaxDegreeOfParallelism.HasValue ?
+                maybeMaxDegreeOfParallelism.Value : DefaultMaxDegreeOfParallelism;
+
+            var sut = new ParticleSwarmOptimizer(parameters,
+            maxIterations: 100,
+            numberOfParticles:10,
+            c1: 2,
+            c2: 2,
+            seed: 42,
+            maxDegreeOfParallelism: maxDegreeOfParallelism);
+
+            return sut;
         }
     }
 }

--- a/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
+++ b/src/SharpLearning.Optimization.Test/RandomSearchOptimizationTest.cs
@@ -43,15 +43,15 @@ namespace SharpLearning.Optimization.Test
             };
 
             var sut = maxDegreeOfParallelism.HasValue ? 
-                new RandomSearchOptimizer(parameters, 2, 42, true, maxDegreeOfParallelism.Value) : 
-                new RandomSearchOptimizer(parameters, 2);
+                new RandomSearchOptimizer(parameters, 100, 42, true, maxDegreeOfParallelism.Value) : 
+                new RandomSearchOptimizer(parameters, 100);
 
             var actual = sut.Optimize(MinimizeWeightFromHeight);
 
             var expected = new OptimizerResult[]
             {
-                new OptimizerResult(new double[] { 13.8749507052707 }, 23438.2157641635),
                 new OptimizerResult(new double[] { 28.3729278125674 },  3690.81119818742),
+                new OptimizerResult(new double[] { 19.1529422843144 }, 14251.396910816733),
             };
 
             Assert.AreEqual(expected.First().Error, actual.First().Error, Delta);

--- a/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
+++ b/src/SharpLearning.Optimization.Test/SmacOptimizerTest.cs
@@ -17,14 +17,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = new SmacOptimizer(parameters,
-                iterations: 80,
-                randomStartingPointCount: 20,
-                functionEvaluationsPerIterationCount: 1,
-                localSearchPointCount: 10,
-                randomSearchPointCount: 1000,
-                epsilon: 0.00001,
-                seed: 42);
+            var sut = CreateSut(parameters);
 
             var actual = sut.OptimizeBest(MinimizeWeightFromHeight);
 
@@ -42,14 +35,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(-10.0, 10.0, Transform.Linear),
             };
 
-            var sut = new SmacOptimizer(parameters,
-                iterations: 80,
-                randomStartingPointCount: 20,
-                functionEvaluationsPerIterationCount: 1,
-                localSearchPointCount: 10,
-                randomSearchPointCount: 1000,
-                epsilon: 0.00001,
-                seed: 42);
+            var sut = CreateSut(parameters);
 
             var actual = sut.OptimizeBest(Minimize);
 
@@ -69,14 +55,7 @@ namespace SharpLearning.Optimization.Test
                 new MinMaxParameterSpec(0.0, 100.0, Transform.Linear)
             };
 
-            var sut = new SmacOptimizer(parameters,
-                iterations: 80,
-                randomStartingPointCount: 20,
-                functionEvaluationsPerIterationCount: 1,
-                localSearchPointCount: 10,
-                randomSearchPointCount: 1000,
-                epsilon: 0.00001,
-                seed: 42);
+            var sut = CreateSut(parameters);
 
             var actual = sut.Optimize(MinimizeWeightFromHeight);
 
@@ -201,6 +180,18 @@ namespace SharpLearning.Optimization.Test
         {
             var sut = new SmacOptimizer(new[] { new GridParameterSpec(0, 1, 2) },
                 10, 20, 30, 40, 0);
+        }
+
+        static SmacOptimizer CreateSut(MinMaxParameterSpec[] parameters)
+        {
+            return new SmacOptimizer(parameters,
+                iterations: 80,
+                randomStartingPointCount: 20,
+                functionEvaluationsPerIterationCount: 1,
+                localSearchPointCount: 10,
+                randomSearchPointCount: 1000,
+                epsilon: 0.00001,
+                seed: 42);
         }
 
         OptimizerResult RunOpenLoopOptimizationTest(List<OptimizerResult> results)

--- a/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
+++ b/src/SharpLearning.Optimization/RandomSearchOptimizer.cs
@@ -16,7 +16,7 @@ namespace SharpLearning.Optimization
         readonly IParameterSpec[] m_parameters;
         readonly int m_iterations;
         readonly IParameterSampler m_sampler;
-        readonly int m_maxDegreeOfParallelism = -1;
+        readonly ParallelOptions m_parallelOptions;
 
         /// <summary>
         /// Random search optimizer initializes random parameters between min and max of the provided parameters.
@@ -27,17 +27,20 @@ namespace SharpLearning.Optimization
         /// <param name="seed"></param>
         /// <param name="runParallel">Use multi threading to speed up execution (default is true)</param>
         /// <param name="maxDegreeOfParallelism">Maximum number of concurrent operations (default is -1 (unlimited))</param>
-        public RandomSearchOptimizer(IParameterSpec[] parameters, 
-            int iterations, 
-            int seed=42, 
-            bool runParallel = true, 
+        public RandomSearchOptimizer(IParameterSpec[] parameters,
+            int iterations,
+            int seed = 42,
+            bool runParallel = true,
             int maxDegreeOfParallelism = -1)
         {
             m_parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
             m_runParallel = runParallel;
             m_sampler = new RandomUniform(seed);
             m_iterations = iterations;
-            m_maxDegreeOfParallelism = maxDegreeOfParallelism;
+            m_parallelOptions = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = maxDegreeOfParallelism
+            };
         }
 
         /// <summary>
@@ -75,12 +78,7 @@ namespace SharpLearning.Optimization
             }
             else
             {
-                var options = new ParallelOptions
-                { 
-                    MaxDegreeOfParallelism = m_maxDegreeOfParallelism 
-                };
-
-                Parallel.For(0, parameterSets.Length, options, (index, loopState) =>
+                Parallel.For(0, parameterSets.Length, m_parallelOptions, (index, loopState) =>
                 {
                     RunParameterSet(index, parameterSets, 
                         functionToMinimize, parameterIndexToResult);


### PR DESCRIPTION
Fix #130 and make order of results deterministic for all optimizers when running with parallel execution. Results will now also be the same between single threaded and multithreaded execution.

This affects all optimizers supporting parallel execution:
 - `BayesianOptimizer`
 - `GlobalizedBoundedNelderMeadOptimizer`
 - `GridSearchOptimizer`
 - `ParticleSwarmOptimizer`
 - `RandomSearchOptimizer`
