### PR TITLE
CI: Use MSTest 3.3.1 (single meta package reference)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>  
     <AssemblyVersion>0.31.0</AssemblyVersion>
-    <FileVersion>0.31.9</FileVersion>
+    <FileVersion>0.31.10</FileVersion>
     <InformationalVersion>$(FileVersion)</InformationalVersion>
     <PackageVersion>$(InformationalVersion)</PackageVersion>
     <!--https://github.com/dotnet/sourcelink/blob/main/docs/README.md#includesourcerevisionininformationalversion-->

--- a/src/SharpLearning.AdaBoost.Test/SharpLearning.AdaBoost.Test.csproj
+++ b/src/SharpLearning.AdaBoost.Test/SharpLearning.AdaBoost.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Containers.Test/SharpLearning.Containers.Test.csproj
+++ b/src/SharpLearning.Containers.Test/SharpLearning.Containers.Test.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
+++ b/src/SharpLearning.CrossValidation.Test/SharpLearning.CrossValidation.Test.csproj
@@ -5,10 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.DecisionTrees.Test/SharpLearning.DecisionTrees.Test.csproj
+++ b/src/SharpLearning.DecisionTrees.Test/SharpLearning.DecisionTrees.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Ensemble.Test/SharpLearning.Ensemble.Test.csproj
+++ b/src/SharpLearning.Ensemble.Test/SharpLearning.Ensemble.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.FeatureTransformations.Test/SharpLearning.FeatureTransformations.Test.csproj
+++ b/src/SharpLearning.FeatureTransformations.Test/SharpLearning.FeatureTransformations.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.GradientBoost.Test/SharpLearning.GradientBoost.Test.csproj
+++ b/src/SharpLearning.GradientBoost.Test/SharpLearning.GradientBoost.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.InputOutput.Test/SharpLearning.InputOutput.Test.csproj
+++ b/src/SharpLearning.InputOutput.Test/SharpLearning.InputOutput.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Metrics.Test/SharpLearning.Metrics.Test.csproj
+++ b/src/SharpLearning.Metrics.Test/SharpLearning.Metrics.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
+++ b/src/SharpLearning.Neural.Test/SharpLearning.Neural.Test.csproj
@@ -7,9 +7,7 @@
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
     <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
+++ b/src/SharpLearning.Optimization.Test/SharpLearning.Optimization.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.RandomForest.Test/SharpLearning.RandomForest.Test.csproj
+++ b/src/SharpLearning.RandomForest.Test/SharpLearning.RandomForest.Test.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpLearning.XGBoost.Test/SharpLearning.XGBoost.Test.csproj
+++ b/src/SharpLearning.XGBoost.Test/SharpLearning.XGBoost.Test.csproj
@@ -7,9 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0-preview.24069.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0-preview.24069.3" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds the following:
- Switch to MSTest single meta package. See more here: https://devblogs.microsoft.com/dotnet/introducing-ms-test-runner/